### PR TITLE
Fixes a bug that caused the session time zone to be set incorrectly when using time zones with active daylight saving time

### DIFF
--- a/Sources/OracleNIO/Extensions/Optional+ValueOrError.swift
+++ b/Sources/OracleNIO/Extensions/Optional+ValueOrError.swift
@@ -7,7 +7,7 @@ extension Optional {
     /// - Parameter error: The error to throw if the optional is `nil`.
     /// - Returns: The value contained in the optional.
     /// - Throws: The error passed in if the optional is `nil`.
-    public func value(or error: Error) throws -> Wrapped {
+    func value(or error: Error) throws -> Wrapped {
         switch self {
         case let .some(value): return value
         case .none: throw error

--- a/Sources/OracleNIO/Helper/Crypto.swift
+++ b/Sources/OracleNIO/Helper/Crypto.swift
@@ -44,19 +44,22 @@ func getSignature(key: String, payload: String) throws -> String {
     if !key.contains({
         Regex {
             Anchor.startOfSubject
-            One("-----BEGIN PRIVATE KEY-----")
+            One("-----BEGIN RSA PRIVATE KEY-----")
             One(.newlineSequence)
             ZeroOrMore(.any)
             One(.newlineSequence)
-            One("-----END PRIVATE KEY-----")
+            One("-----END RSA PRIVATE KEY-----")
             Anchor.endOfSubject
         }
     }) {
-        key = "-----BEGIN PRIVATE KEY-----" + "\n" +
-            key + "\n" + "-----END PRIVATE KEY-----"
+        key = "-----BEGIN RSA PRIVATE KEY-----" + "\n" +
+            key + "\n" + "-----END RSA PRIVATE KEY-----"
     }
     guard let payload = payload.data(using: .utf8) else {
         throw CryptoKitError.invalidParameter
     }
-    return try _RSA.Signing.PrivateKey(pemRepresentation: key).signature(for: payload, padding: .insecurePKCS1v1_5).rawRepresentation.base64EncodedString()
+    return try _RSA.Signing.PrivateKey(pemRepresentation: key)
+        .signature(for: payload, padding: .insecurePKCS1v1_5)
+        .rawRepresentation
+        .base64EncodedString()
 }

--- a/Sources/OracleNIO/Helper/Crypto.swift
+++ b/Sources/OracleNIO/Helper/Crypto.swift
@@ -40,24 +40,7 @@ func getDerivedKey(key: Data, salt: [UInt8], length: Int, iterations: Int) throw
 /// Returns a signed version of the given payload (used for Oracle IAM token authentication) in base64
 /// encoding.
 func getSignature(key: String, payload: String) throws -> String {
-    var key = key
-    if !key.contains({
-        Regex {
-            Anchor.startOfSubject
-            One("-----BEGIN RSA PRIVATE KEY-----")
-            One(.newlineSequence)
-            ZeroOrMore(.any)
-            One(.newlineSequence)
-            One("-----END RSA PRIVATE KEY-----")
-            Anchor.endOfSubject
-        }
-    }) {
-        key = "-----BEGIN RSA PRIVATE KEY-----" + "\n" +
-            key + "\n" + "-----END RSA PRIVATE KEY-----"
-    }
-    guard let payload = payload.data(using: .utf8) else {
-        throw CryptoKitError.invalidParameter
-    }
+    let payload = Array(payload.utf8)
     return try _RSA.Signing.PrivateKey(pemRepresentation: key)
         .signature(for: payload, padding: .insecurePKCS1v1_5)
         .rawRepresentation

--- a/Sources/OracleNIO/Messages/Coding/OracleFrontendMessageEncoder.swift
+++ b/Sources/OracleNIO/Messages/Coding/OracleFrontendMessageEncoder.swift
@@ -341,12 +341,7 @@ struct OracleFrontendMessageEncoder {
                 self.writeKeyValuePair(key: "AUTH_TOKEN", value: token)
             case .tokenAndPrivateKey(let token, let key):
                 self.writeKeyValuePair(key: "AUTH_TOKEN", value: token)
-                let format = "E, dd MMM yyyy HH:mm:ss 'GMT'"
-                let formatter = DateFormatter()
-                formatter.dateFormat = format
-                formatter.locale = Locale(identifier: "en_US_POSIX")
-                formatter.timeZone = TimeZone(abbreviation: "GMT")
-                let now = formatter.string(from: .now)
+                let now = authHeaderDateFormatter.string(from: .now)
                 let hostInfo = """
                 \(authContext.peerAddress?.ipAddress ?? ""):\
                 \(authContext.peerAddress?.port ?? 0)
@@ -1248,3 +1243,12 @@ enum OracleFrontendMessageID: UInt8 {
     case onewayFN = 26
     case fastAuth = 34
 }
+
+private let authHeaderDateFormatter: DateFormatter = {
+    let format = "E, dd MMM yyyy HH:mm:ss 'GMT'"
+    let formatter = DateFormatter()
+    formatter.dateFormat = format
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.timeZone = TimeZone(abbreviation: "GMT")
+    return formatter
+}()

--- a/Sources/OracleNIO/Messages/Coding/OracleFrontendMessageEncoder.swift
+++ b/Sources/OracleNIO/Messages/Coding/OracleFrontendMessageEncoder.swift
@@ -408,7 +408,7 @@ struct OracleFrontendMessageEncoder {
         )
         self.writeKeyValuePair(
             key: "AUTH_ALTER_SESSION",
-            value: self.getAlterTimezoneStatement(
+            value: self._getAlterTimezoneStatement(
                 customTimezone: authContext.customTimezone
             ),
             flags: 1
@@ -1209,16 +1209,13 @@ extension OracleFrontendMessageEncoder {
         self.buffer.writeImmutableBuffer(bindings.bytes)
     }
 
-    /// Returns the statement required to change the session time zone to match the time zone in use
-    /// by the client (us).
-    private mutating func getAlterTimezoneStatement(customTimezone: TimeZone?) -> String {
+    /// Returns the statement required to change the session time zone 
+    /// to match the time zone in use by the client (us).
+    ///
+    /// _Not private due to tests._
+    internal func _getAlterTimezoneStatement(customTimezone: TimeZone?, atDate date: Date = .init()) -> String {
         let timezone = customTimezone ?? TimeZone.current
-        let now = Date.now
-        var offset = timezone.secondsFromGMT(for: now)
-        let isDaylightSavingTime = timezone.isDaylightSavingTime(for: now)
-        if isDaylightSavingTime {
-            offset -= Int(timezone.daylightSavingTimeOffset(for: now))
-        }
+        let offset = timezone.secondsFromGMT(for: date)
         let tzHour = abs(offset / 3600)
         let tzMinute = (abs(offset) % 3600) / 60
         let sign = offset >= 0 ? "+" : "-"

--- a/Sources/OracleNIO/OracleDecodingError.swift
+++ b/Sources/OracleNIO/OracleDecodingError.swift
@@ -113,15 +113,24 @@ public struct OracleDecodingError: Error, Equatable {
 
 extension OracleDecodingError: CustomStringConvertible {
     public var description: String {
-        // This may seem very odd... But we are afraid that users might 
-        // accidentally send the unfiltered errors out to end-users. This may
-        // leak security relevant information. For this reason we overwrite
-        // the error description by default to this generic "Database error"
-        """
-        OracleDecodingError – Generic description to prevent accidental \
-        leakage of sensitive data. For debugging details, use \
+        var result = #"OracleDecodingError(code: \#(self.code)"#
+
+        result.append(#", columnName: \#(String(repeating: "*", count: self.columnName.count))"#)
+        result.append(#", columnIndex: \#(self.columnIndex)"#)
+        result.append(#", targetType: \#(String(reflecting: self.targetType))"#)
+        result.append(#", oracleType: \#(self.oracleType)"#)
+        if let oracleData {
+            result.append(#", oracleData: \#(String(reflecting: oracleData))"#)
+        }
+        result.append(") ")
+
+        result.append("""
+        - Some information has been reducted to prevent accidental leakage of \
+        sensitive data. For additional debugging details, use \
         `String(reflecting: error)`.
-        """
+        """)
+
+        return result
     }
 }
 

--- a/Sources/OracleNIO/OracleSQLError.swift
+++ b/Sources/OracleNIO/OracleSQLError.swift
@@ -333,7 +333,7 @@ extension OracleSQLError: CustomStringConvertible {
         result.append(") ")
 
         result.append("""
-        Some information has been reducted to prevent accidental leakage of \
+        - Some information has been reducted to prevent accidental leakage of \
         sensitive data. For additional debugging details, use `String(reflecting: error)`.
         """)
 

--- a/Tests/OracleNIOTests/Messages/AuthenticationPhaseTwoMessageTests.swift
+++ b/Tests/OracleNIOTests/Messages/AuthenticationPhaseTwoMessageTests.swift
@@ -1,0 +1,49 @@
+// Copyright 2024 Timo Zacherl
+// SPDX-License-Identifier: Apache-2.0
+
+import XCTest
+import NIOCore
+import NIOTestUtils
+@testable import OracleNIO
+
+final class AuthenticationPhaseTwoMessageTests: XCTestCase {
+    let testPrivateKey = """
+    -----BEGIN RSA PRIVATE KEY-----
+    MIICWgIBAAKBgGhXeKN8/4vESCXIgvZV+61Pp8sCWlnBGuOSgQ0wAHzvz9VVm8fs
+    2k69hhzpYWsbmlpEUTNZaSsdxIVqKuo0dLrA/cK4CRJI4t35PmIlaEF852nk+5nL
+    azYmurtyl1LwMTJ9toC9d1TpM5+Fl/aXQ8SP2Kycaw/9P9HNSQPSxqsrAgMBAAEC
+    gYAE1dDcWqWI946UWadf/PoNvPw8lx5SvHUfiKF8V/Yd1AsgirgOWrZ/IZ8+Zb5C
+    9WOAvVu58nHCMr3xpMraUZX7JmFXRjRZ/uRjxlbj4zwEZkTqfNdOOzHb5XSgQBWe
+    +w+MWEOUP647SmCGMvwjzVZIYNwBz9RXx8M+Odp/ti7/sQJBAKecghe+0jHDyDxT
+    K2wkxvZ6tdDIr/MGxo4uT/bXbxpBVhmyx2TIDBrISjxjTOyOTi8nglkHrBA7zjSX
+    JIkeGgMCQQCfXZKZEoPtHFTP/1dAJDyLijoKxoFyjtP2k4Z7VsUt+rNbAGSxkvbS
+    T/kxvlUUfYPv3+Q6m9DTDR5kywdFC/W5AkB8FxsZiWUFAvXT859KSVAkW2UQVgQt
+    4O5PhWoeThErVwPvsrR8oL6VdYPAgaQJ3rFzp8SRNWTl/+ECfoPGIEsRAkBVNDMv
+    0f1k5TPXLP6aFYWlWVbk8fK9q+1ZtNA+20p65cHE0rYDVr7N/OIPnWJhnSXQNxUP
+    3MTOQgJRA1e0q8tJAkAUYktgG/+Zu0OKmRLRKQEe0XZ69lN7+rtUWfm9O4pCc+CD
+    kbg+3wsQXo3qc85xJMKZabpbW4Gj5p6qqpm2wd2e
+    -----END RSA PRIVATE KEY-----
+    """
+
+    func testEncodeWithTokenAndPrivateKeyDoesNotFailWithValidKey() throws {
+        let context = AuthContext(
+            method: .init(token: .tokenAndPrivateKey(token: "my_token", key: testPrivateKey)),
+            service: .serviceName("test"),
+            terminalName: "terminal",
+            programName: "program",
+            machineName: "machine",
+            pid: 1,
+            processUsername: "user",
+            mode: .sysDBA,
+            description: .init(
+                connectionID: "1",
+                addressLists: [],
+                service: .serviceName("test"),
+                sslServerDnMatch: false,
+                purity: .new
+            )
+        )
+        var encoder = OracleFrontendMessageEncoder(buffer: .init(), capabilities: .init())
+        try encoder.authenticationPhaseTwo(authContext: context, parameters: .init([:]))
+    }
+}

--- a/Tests/OracleNIOTests/Messages/OracleFrontendMessageEncoderTests.swift
+++ b/Tests/OracleNIOTests/Messages/OracleFrontendMessageEncoderTests.swift
@@ -1,0 +1,18 @@
+// Copyright 2024 Timo Zacherl
+// SPDX-License-Identifier: Apache-2.0
+
+import XCTest
+@testable import OracleNIO
+
+final class OracleFrontendMessageEncoderTests: XCTestCase {
+    func testAlterTimezone() {
+        let berlin = TimeZone(identifier: "Europe/Berlin")
+        let encoder = OracleFrontendMessageEncoder(buffer: .init(), capabilities: .init())
+        let summer2024 = Date(timeIntervalSince1970: 1717236000) // 2024-12-01 12:00:00 +01:00
+        let winter2024 = Date(timeIntervalSince1970: 1733050800) // 2024-06-01 11:00:00 +01:00
+        let summerStatement = encoder._getAlterTimezoneStatement(customTimezone: berlin, atDate: summer2024)
+        let winterStatement = encoder._getAlterTimezoneStatement(customTimezone: berlin, atDate: winter2024)
+        XCTAssertEqual(summerStatement, "ALTER SESSION SET TIME_ZONE='+02:00'\0")
+        XCTAssertEqual(winterStatement, "ALTER SESSION SET TIME_ZONE='+01:00'\0")
+    }
+}

--- a/Tests/OracleNIOTests/OracleCodableTests.swift
+++ b/Tests/OracleNIOTests/OracleCodableTests.swift
@@ -154,6 +154,31 @@ final class OracleCodableTests: XCTestCase {
         XCTAssertEqual(result.2, 420.081500420)
     }
 
+    func testDecodeMalformedRowFailsWithDetails() {
+        let row = OracleRow(
+            lookupTable: ["int": 0],
+            data: .init(columnCount: 1, bytes: .init(bytes: [1, 0])),
+            columns: [
+                .init(
+                    name: "int",
+                    dataType: .binaryInteger,
+                    dataTypeSize: 1,
+                    precision: 1,
+                    scale: 1,
+                    bufferSize: 1,
+                    nullsAllowed: true
+                )
+            ]
+        )
+
+        do {
+            _ = try row.decode(String.self)
+        } catch {
+            XCTAssertTrue("\(error)".contains("columnName: ***")) // should be redacted
+            XCTAssertTrue(String(reflecting: error).contains(#"columnName: "int""#))
+        }
+    }
+
 }
 
 extension DataRow: ExpressibleByArrayLiteral {


### PR DESCRIPTION
Also improves error descriptions and internalizes a previously public helper method `Optional.value(or:)`, which should've never been public in the first place.