### PR TITLE
Close open cursor when statement returns no rows

### DIFF
--- a/Sources/OracleNIO/OracleChannelHandler.swift
+++ b/Sources/OracleNIO/OracleChannelHandler.swift
@@ -745,6 +745,9 @@ final class OracleChannelHandler: ChannelDuplexHandler {
                 batchErrors: result.batchErrors
             )
             promise.succeed(rows)
+            if let cursorID = result.cursorID, cursorID != 0 {
+                cleanupContext.cursorsToClose.insert(cursorID)
+            }
             self.run(self.state.readyForStatementReceived(), with: context)
         }
 


### PR DESCRIPTION
Previously, cursors have not been closed on statements that didn't return rows. 
This might've led to `ORA-01000: maximum open cursors for session exceeded` errors after a lot of actions have been performed (depending on the db config usually between 299-999 statements).

This change fixes the error described above (cc @kicsipixel). 