### PR TITLE
Fix encoding of JSON and VECTOR data exceeding the TNS_MAX_SHORT_LENGTH

### DIFF
--- a/Sources/OracleNIO/Data/JSON/OracleJSON+Encoding.swift
+++ b/Sources/OracleNIO/Data/JSON/OracleJSON+Encoding.swift
@@ -32,13 +32,7 @@ extension OracleJSON: OracleThrowingDynamicTypeEncodable where Value: Encodable 
         var temp = ByteBuffer()
         try self.encode(into: &temp, context: context)
         buffer.writeQLocator(dataLength: UInt64(temp.readableBytes))
-        if temp.readableBytes <= Constants.TNS_OBJ_MAX_SHORT_LENGTH {
-            buffer.writeInteger(UInt8(temp.readableBytes))
-        } else {
-            buffer.writeInteger(Constants.TNS_LONG_LENGTH_INDICATOR)
-            buffer.writeInteger(UInt32(temp.readableBytes))
-        }
-        buffer.writeBuffer(&temp)
+        temp._encodeRaw(into: &buffer, context: context)
     }
 
     public func encode(

--- a/Sources/OracleNIO/Data/OracleVector.swift
+++ b/Sources/OracleNIO/Data/OracleVector.swift
@@ -389,13 +389,7 @@ extension _OracleVectorProtocol {
         )
         self.encode(into: &temp, context: context)
         buffer.writeQLocator(dataLength: UInt64(temp.readableBytes))
-        if temp.readableBytes <= Constants.TNS_OBJ_MAX_SHORT_LENGTH {
-            buffer.writeInteger(UInt8(temp.readableBytes))
-        } else {
-            buffer.writeInteger(Constants.TNS_LONG_LENGTH_INDICATOR)
-            buffer.writeInteger(UInt32(temp.readableBytes))
-        }
-        buffer.writeBuffer(&temp)
+        temp._encodeRaw(into: &buffer, context: context)
     }
 
     @inlinable

--- a/Sources/OracleNIO/Messages/Coding/OracleFrontendMessageEncoder.swift
+++ b/Sources/OracleNIO/Messages/Coding/OracleFrontendMessageEncoder.swift
@@ -598,13 +598,11 @@ struct OracleFrontendMessageEncoder {
         self.buffer.writeUB4(0)  // al8i4[4]
         self.buffer.writeUB4(0)  // al8i4[5] SCN (part 1)
         self.buffer.writeUB4(0)  // al8i4[6] SCN (part 2)
-        self.buffer.writeUB4(
-            statementContext.type.isQuery ? 1 : 0
-        )  // al8i4[7] is query
+        self.buffer.writeUB4(statementContext.type.isQuery ? 1 : 0)  // al8i4[7] is query
         self.buffer.writeUB4(0)  // al8i4[8]
-        self.buffer.writeUB4(dmlOptions)  // al8i4[9] DML row counts/implicit
-        self.buffer.writeUB4(0)  // al8i4[10]
-        self.buffer.writeUB4(0)  // al8i4[11]
+        self.buffer.writeUB4(dmlOptions)  // al8i4[9] execute flags
+        self.buffer.writeUB4(0)  // al8i4[10] fetch orientation
+        self.buffer.writeUB4(0)  // al8i4[11] fetch position
         self.buffer.writeUB4(0)  // al8i4[12]
         if requiresDefine {
             guard let columns = describeInfo?.columns else {

--- a/Tests/OracleNIOTests/Data/OracleJSONWriterTests.swift
+++ b/Tests/OracleNIOTests/Data/OracleJSONWriterTests.swift
@@ -227,5 +227,32 @@
             let result = try OracleJSONParser.parse(from: &buffer)
             #expect(result == .container([key: .string("value")]))
         }
+
+        @Test func encodeObjectWithNestedObjectArray() throws {
+            var buffer = ByteBuffer()
+            var writer = OracleJSONWriter()
+            let json: OracleJSONStorage = .container([
+                "name": .string("String"),
+                "address": .container([
+                    "city": .string("String"),
+                    "street": .string("String"),
+                    "zip": .string("String"),
+                ]),
+                "email": .array([.string("String")]),
+                "phone": .array([.string("String")]),
+                "web": .array([.string("String")]),
+                "openingHours": .array([
+                    .container([
+                        "day_of_week": .string("Tuesday"),
+                        "opens": .string("08:00"),
+                        "closes": .string("18:00"),
+                    ])
+                ]),
+            ])
+
+            try writer.encode(json, into: &buffer, maxFieldNameSize: 65535)
+            let result = try OracleJSONParser.parse(from: &buffer)
+            #expect(result == json)
+        }
     }
 #endif


### PR DESCRIPTION
This fixes ORA-03138 and ORA-03146 when inserting JSON or VECTOR data. (cc @kicsipixel)