### PR TITLE
Fix EXPIRED(GRACE) connect hang in BackendError.decodeWarning

### DIFF
--- a/Sources/OracleNIO/Messages/BackendError.swift
+++ b/Sources/OracleNIO/Messages/BackendError.swift
@@ -39,17 +39,19 @@ struct BackendError: OracleBackendMessage.PayloadDecodable, Hashable, Sendable {
         context: OracleBackendMessageDecoder.Context
     ) throws -> BackendError {
         // Oracle's TNS warning packet uses the UB2 (variable-length) encoding
-        // for the error number, message length, and flags fields — same as
-        // every other UB2-shaped field in the protocol. Reading raw UInt16
-        // here was the bug that caused EXPIRED(GRACE) accounts to hang the
-        // connect: the decoder pulled garbage for `length`, ran past the end
-        // of the message, and threw a partial-decode that buffered forever.
+        // for the error number, message length, and flags fields, and the
+        // message itself uses Oracle's chunked length-prefixed string format
+        // (same as the regular error path below). Reading raw UInt16 here, or
+        // reading the message as a fixed-length string, both desynchronise the
+        // decoder by one or more bytes — the trailing newline of the warning
+        // string then surfaces as a bogus messageID (e.g. 10 = 0x0A) on the
+        // next decode pass. Matches python-oracledb's `_process_warning_info`.
         let number = try buffer.throwingReadUB2()
         let length = try buffer.throwingReadUB2()
         try buffer.throwingSkipUB2()  // flags
         let errorMessage: String? =
             if number != 0 && length > 0 {
-                try buffer.throwingReadString(length: Int(length)).replacing(/(^\s+|\s+$)/, with: "")
+                try buffer.readString().replacing(/(^\s+|\s+$)/, with: "")
             } else {
                 nil
             }

--- a/Sources/OracleNIO/Messages/BackendError.swift
+++ b/Sources/OracleNIO/Messages/BackendError.swift
@@ -38,11 +38,15 @@ struct BackendError: OracleBackendMessage.PayloadDecodable, Hashable, Sendable {
         from buffer: inout ByteBuffer,
         context: OracleBackendMessageDecoder.Context
     ) throws -> BackendError {
-        let number = try buffer.throwingReadInteger(as: UInt16.self)
-        // error number
-        let length = try buffer.throwingReadInteger(as: UInt16.self)
-        // length of error message
-        try buffer.throwingMoveReaderIndex(forwardBy: 2)  // skip flags
+        // Oracle's TNS warning packet uses the UB2 (variable-length) encoding
+        // for the error number, message length, and flags fields — same as
+        // every other UB2-shaped field in the protocol. Reading raw UInt16
+        // here was the bug that caused EXPIRED(GRACE) accounts to hang the
+        // connect: the decoder pulled garbage for `length`, ran past the end
+        // of the message, and threw a partial-decode that buffered forever.
+        let number = try buffer.throwingReadUB2()
+        let length = try buffer.throwingReadUB2()
+        try buffer.throwingSkipUB2()  // flags
         let errorMessage: String? =
             if number != 0 && length > 0 {
                 try buffer.throwingReadString(length: Int(length)).replacing(/(^\s+|\s+$)/, with: "")

--- a/Tests/IntegrationTests/OracleNIOTests.swift
+++ b/Tests/IntegrationTests/OracleNIOTests.swift
@@ -68,6 +68,48 @@ final class OracleNIOTests {
         #expect(throws: Never.self, performing: { try conn?.syncClose() })
     }
 
+    // Real-connection regression for the EXPIRED(GRACE) hang
+    // (https://github.com/lovetodream/oracle-nio/issues/113). Reuses the
+    // standard ORA_HOSTNAME / ORA_PORT / ORA_SERVICE_NAME env, but expects a
+    // separate user whose account_status is EXPIRED(GRACE). The test is
+    // skipped automatically when ORA_GRACE_USERNAME / ORA_GRACE_PASSWORD are
+    // not set, so it doesn't fail the suite on DBs that don't have the
+    // grace user provisioned.
+    //
+    // One-time setup against the target DB:
+    //   CREATE PROFILE temp_expire_1m LIMIT
+    //     PASSWORD_LIFE_TIME 1/1440 PASSWORD_GRACE_TIME 7;
+    //   CREATE USER testpwd IDENTIFIED BY testpwd;
+    //   GRANT CREATE SESSION TO testpwd;
+    //   ALTER USER testpwd PROFILE temp_expire_1m;
+    //   ALTER USER testpwd IDENTIFIED BY testpwd;
+    //   -- wait > 1 minute so account_status flips to EXPIRED(GRACE)
+    @Test(.enabled(if: env("ORA_GRACE_USERNAME") != nil || env("ORA_GRACE_PASSWORD") != nil))
+    func connectToGraceExpiredAccountDoesNotHang() async throws {
+        var config = OracleConnection.Configuration(
+            host: env("ORA_HOSTNAME") ?? "192.168.1.24",
+            port: env("ORA_PORT").flatMap(Int.init) ?? 1521,
+            service: .serviceName(env("ORA_SERVICE_NAME") ?? "XEPDB1"),
+            username: env("ORA_GRACE_USERNAME") ?? "testpwd",
+            password: env("ORA_GRACE_PASSWORD") ?? "testpwd"
+        )
+        // Tight connect timeout so a regression of the hang surfaces as a
+        // clear failure rather than blocking until the suite-level limit.
+        config.options.connectTimeout = .seconds(15)
+
+        let connection = try await OracleConnection.connect(
+            on: self.eventLoop, configuration: config, id: 0, logger: .oracleTest
+        )
+        defer { #expect(throws: Never.self, performing: { try connection.syncClose() }) }
+
+        // Prove the session is actually usable, not just past the auth hang.
+        let rows = try await connection.execute(
+            "SELECT 'grace-ok' FROM dual", logger: .oracleTest
+        ).collect()
+        #expect(rows.count == 1)
+        #expect(try rows.first?.decode(String.self) == "grace-ok")
+    }
+
     @Test func multipleFailingAttempts() async throws {
         var config = OracleConnection.Configuration(
             host: env("ORA_HOSTNAME") ?? "192.168.1.24",

--- a/Tests/OracleNIOTests/Messages/WarningMessageTests.swift
+++ b/Tests/OracleNIOTests/Messages/WarningMessageTests.swift
@@ -1,0 +1,88 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the OracleNIO open source project
+//
+// Copyright (c) 2026 Timo Zacherl and the OracleNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of OracleNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOCore
+import Testing
+
+@testable import OracleNIO
+
+@Suite(.timeLimit(.minutes(5))) struct WarningMessageTests {
+    // Regression: a warning whose message ends in a newline (e.g. ORA-28098
+    // sent for an EXPIRED(GRACE) account) used to leave the trailing byte
+    // unread, so the next decode pass interpreted that byte (0x0A) as a bogus
+    // messageID '10'. See https://github.com/lovetodream/oracle-nio/issues/113.
+    @Test func decodeWarningEndingInNewlineConsumesAllBytes() throws {
+        // data flags        : 00 00
+        // messageID warning : 0F
+        // UB2 number 28098  : 02 6D C2
+        // UB2 length 13     : 01 0D
+        // UB2 flags         : 01 04
+        // chunked length 13 : 0D
+        // "ORA-1: hello\n"  : 4F 52 41 2D 31 3A 20 68 65 6C 6C 6F 0A
+        var buffer = try ByteBuffer(
+            plainHexEncodedBytes:
+                "00 00 0F 02 6D C2 01 0D 01 04 0D 4F 52 41 2D 31 3A 20 68 65 6C 6C 6F 0A"
+        )
+
+        let (messages, _) = try OracleBackendMessage.decode(
+            from: &buffer,
+            of: .data,
+            context: .init(capabilities: .desired())
+        )
+
+        #expect(buffer.readableBytes == 0)
+        #expect(messages.count == 1)
+        guard case .warning(let warning) = messages.first else {
+            Issue.record("expected .warning, got \(String(describing: messages.first))")
+            return
+        }
+        #expect(warning.number == 28098)
+        #expect(warning.isWarning)
+        #expect(warning.message == "ORA-1: hello")
+    }
+
+    // A second message immediately after the warning must still be aligned —
+    // catches off-by-one regressions in the warning decoder.
+    @Test func decodeWarningFollowedByAnotherMessageAlignsCorrectly() throws {
+        // first warning (same payload as above)
+        // second warning : 0F  number=1 (01 01) length=0 (00) flags=00
+        var buffer = try ByteBuffer(
+            plainHexEncodedBytes:
+                "00 00 0F 02 6D C2 01 0D 01 04 0D 4F 52 41 2D 31 3A 20 68 65 6C 6C 6F 0A"
+                + "0F 01 01 00 00"
+        )
+
+        let (messages, _) = try OracleBackendMessage.decode(
+            from: &buffer,
+            of: .data,
+            context: .init(capabilities: .desired())
+        )
+
+        #expect(buffer.readableBytes == 0)
+        #expect(messages.count == 2)
+        guard case .warning(let first) = messages.first else {
+            Issue.record("expected .warning, got \(String(describing: messages.first))")
+            return
+        }
+        #expect(first.number == 28098)
+        #expect(first.message == "ORA-1: hello")
+
+        guard messages.count == 2, case .warning(let second) = messages[1] else {
+            Issue.record("expected second .warning")
+            return
+        }
+        #expect(second.number == 1)
+        #expect(second.message == nil)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #113. `OracleConnection.connect` hangs forever at auth phase two when the target account is in `EXPIRED(GRACE)` state, because `BackendError.decodeWarning` mis-decodes the `ORA-28098` warning the server prepends to the auth-result packet. Two byte-level decoding bugs combine into the hang:

1. The error number, message length, and flags fields are read as raw `UInt16` instead of UB2 (variable-length, length-prefixed). The wrong header read makes the rest of the warning unreadable, the partial-decode error leaves the buffer mid-message, and the connect sits in a wait loop forever.
2. The message body is then read as a fixed-length string, which skips Oracle's chunked length-prefix byte and leaves the trailing newline of the warning in the buffer. On the next decode pass that `0x0A` byte is interpreted as a bogus `messageID '10'` and aborts the connect.

Both fixes match python-oracledb's `_process_warning_info` (UB2 reads + chunked `read_str`).

## Commits

- `Fix BackendError.decodeWarning UB2 decoding` — switch the three header fields to `throwingReadUB2` / `throwingSkipUB2`.
- `Read warning message as chunked string in BackendError.decodeWarning` — switch the body to the chunked `readString()` already used by the regular error path.
- `Add EXPIRED(GRACE) integration test alongside existing auth-flow tests` — real-connection regression on the existing integration `OracleNIOTests` suite, gated by `ORA_GRACE_USERNAME` / `ORA_GRACE_PASSWORD` so it skips on DBs without the grace user provisioned.

## Test plan

- [x] Two synthetic unit tests in `Tests/OracleNIOTests/Messages/WarningMessageTests.swift` exercising the data-packet decode path. Verified to fail with the exact upstream `messageID '10'` error when the chunked-string fix is reverted, pass with both fixes in place.
- [x] Real-connection integration test against a local Oracle Free 23ai DB with a `testpwd` user in `EXPIRED(GRACE)` state. Connect now completes in ~50ms (vs. hanging indefinitely before) and both `ORA-28098` warnings surface as expected.
- [x] Existing unit and integration suites still pass.

### Reproducing

```sql
CREATE PROFILE temp_expire_1m LIMIT
  PASSWORD_LIFE_TIME 1/1440 PASSWORD_GRACE_TIME 7;
CREATE USER testpwd IDENTIFIED BY testpwd;
GRANT CREATE SESSION TO testpwd;
ALTER USER testpwd PROFILE temp_expire_1m;
ALTER USER testpwd IDENTIFIED BY testpwd;
-- wait > 1 minute so account_status flips to EXPIRED(GRACE)
```

```bash
ORA_HOSTNAME=localhost ORA_PORT=1521 ORA_SERVICE_NAME=orcl \
ORA_GRACE_USERNAME=testpwd ORA_GRACE_PASSWORD=testpwd \
swift test --filter "OracleNIOTests/connectToGraceExpiredAccountDoesNotHang"

swift test --filter "WarningMessageTests"
```