### PR TITLE
Fix UInt8 over/underflow in TIMESTAMP TZ codec for negative offsets

### DIFF
--- a/Sources/OracleNIO/Data/Date+OracleCodable.swift
+++ b/Sources/OracleNIO/Data/Date+OracleCodable.swift
@@ -70,8 +70,8 @@ extension Date: OracleEncodable {
             let totalMinutes = seconds / 60
             let hours = totalMinutes / 60
             let minutes = totalMinutes % 60
-            buffer.writeInteger(UInt8(hours) + Constants.TZ_HOUR_OFFSET)
-            buffer.writeInteger(UInt8(minutes) + Constants.TZ_MINUTE_OFFSET)
+            buffer.writeInteger(UInt8(hours + Int(Constants.TZ_HOUR_OFFSET)))
+            buffer.writeInteger(UInt8(minutes + Int(Constants.TZ_MINUTE_OFFSET)))
         }
     }
 }
@@ -123,8 +123,8 @@ extension Date: OracleDecodable {
                     throw OracleDecodingError.Code.failure
                 }
 
-                let tzHour = Int(byte11 - Constants.TZ_HOUR_OFFSET)
-                let tzMinute = Int(byte12 - Constants.TZ_MINUTE_OFFSET)
+                let tzHour = Int(byte11) - Int(Constants.TZ_HOUR_OFFSET)
+                let tzMinute = Int(byte12) - Int(Constants.TZ_MINUTE_OFFSET)
                 if tzHour != 0 || tzMinute != 0 {
                     guard
                         let timeZone = TimeZone(

--- a/Tests/OracleNIOTests/OracleCodableTests.swift
+++ b/Tests/OracleNIOTests/OracleCodableTests.swift
@@ -156,6 +156,46 @@ import Testing
         )
     }
 
+    @Test func decodeTimestampTZWithNegativeOffset() throws {
+        // TIMESTAMP WITH TIME ZONE encoded with a negative UTC offset (-07:00).
+        // Wire layout: 7 base bytes + 4 fractional-second bytes + 2 TZ bytes.
+        // For -07:00, byte11 = TZ_HOUR_OFFSET + (-7) = 13, byte12 = TZ_MINUTE_OFFSET + 0 = 60.
+        // Pre-fix this trapped on UInt8 underflow inside the decoder.
+        var buffer = ByteBuffer()
+        buffer.writeInteger(UInt8(120))   // year hi: 100 + 2025/100 = 100 + 20 = 120
+        buffer.writeInteger(UInt8(125))   // year lo: 100 + 2025%100 = 100 + 25 = 125
+        buffer.writeInteger(UInt8(4))     // month
+        buffer.writeInteger(UInt8(26))    // day
+        buffer.writeInteger(UInt8(13))    // hour + 1 (12:00:00 UTC)
+        buffer.writeInteger(UInt8(1))     // minute + 1 (0)
+        buffer.writeInteger(UInt8(1))     // second + 1 (0)
+        buffer.writeInteger(UInt32(0), endianness: .big, as: UInt32.self) // fractional seconds = 0
+        buffer.writeInteger(UInt8(13))    // tz hour byte: -7 + 20
+        buffer.writeInteger(UInt8(60))    // tz minute byte: 0 + 60
+
+        let decoded = try Date(from: &buffer, type: .timestampTZ, context: .default)
+
+        var utc = Calendar(identifier: .gregorian)
+        utc.timeZone = TimeZone(secondsFromGMT: 0)!
+        let expected = utc.date(from: DateComponents(
+            calendar: utc, timeZone: TimeZone(secondsFromGMT: 0),
+            year: 2025, month: 4, day: 26, hour: 12, minute: 0, second: 0, nanosecond: 0
+        ))!
+        #expect(decoded == expected)
+    }
+
+    @Test func roundTripDateThroughTimestampTZWithNegativeLocalOffset() throws {
+        // Encoding a Date when the current timezone has a negative offset must not trap.
+        // We can't force the process timezone here, so we instead exercise the encoder math
+        // for a known-bad pair (hours = -7, minutes = 0): pre-fix this trapped on UInt8(-7).
+        let hours = -7
+        let minutes = 0
+        var buffer = ByteBuffer()
+        buffer.writeInteger(UInt8(hours + Int(Constants.TZ_HOUR_OFFSET)))
+        buffer.writeInteger(UInt8(minutes + Int(Constants.TZ_MINUTE_OFFSET)))
+        #expect(buffer.readableBytes == 2)
+    }
+
     @Test func decodeDifferentNumericsFromARow() throws {
         let row = OracleRow(
             lookupTable: ["int": 0, "float": 1, "double": 2],

--- a/Tests/OracleNIOTests/OracleCodableTests.swift
+++ b/Tests/OracleNIOTests/OracleCodableTests.swift
@@ -156,44 +156,91 @@ import Testing
         )
     }
 
-    @Test func decodeTimestampTZWithNegativeOffset() throws {
-        // TIMESTAMP WITH TIME ZONE encoded with a negative UTC offset (-07:00).
-        // Wire layout: 7 base bytes + 4 fractional-second bytes + 2 TZ bytes.
-        // For -07:00, byte11 = TZ_HOUR_OFFSET + (-7) = 13, byte12 = TZ_MINUTE_OFFSET + 0 = 60.
-        // Pre-fix this trapped on UInt8 underflow inside the decoder.
+    /// Builds an Oracle TIMESTAMP-family wire buffer for 2025-04-26 12:00:00 UTC with the
+    /// given timezone offset bytes appended (when non-nil). Year/month/day/hour/min/sec are
+    /// always stored in UTC on the wire; the trailing two bytes only carry display zone.
+    private func makeTimestampBuffer(tzHourByte: UInt8?, tzMinuteByte: UInt8?) -> ByteBuffer {
         var buffer = ByteBuffer()
-        buffer.writeInteger(UInt8(120))   // year hi: 100 + 2025/100 = 100 + 20 = 120
-        buffer.writeInteger(UInt8(125))   // year lo: 100 + 2025%100 = 100 + 25 = 125
-        buffer.writeInteger(UInt8(4))     // month
-        buffer.writeInteger(UInt8(26))    // day
-        buffer.writeInteger(UInt8(13))    // hour + 1 (12:00:00 UTC)
-        buffer.writeInteger(UInt8(1))     // minute + 1 (0)
-        buffer.writeInteger(UInt8(1))     // second + 1 (0)
-        buffer.writeInteger(UInt32(0), endianness: .big, as: UInt32.self) // fractional seconds = 0
-        buffer.writeInteger(UInt8(13))    // tz hour byte: -7 + 20
-        buffer.writeInteger(UInt8(60))    // tz minute byte: 0 + 60
+        buffer.writeInteger(UInt8(120))  // year hi: 100 + 2025/100
+        buffer.writeInteger(UInt8(125))  // year lo: 100 + 2025%100
+        buffer.writeInteger(UInt8(4))    // month
+        buffer.writeInteger(UInt8(26))   // day
+        buffer.writeInteger(UInt8(13))   // hour + 1 (12:00:00 UTC)
+        buffer.writeInteger(UInt8(1))    // minute + 1 (0)
+        buffer.writeInteger(UInt8(1))    // second + 1 (0)
+        buffer.writeInteger(UInt32(0), endianness: .big, as: UInt32.self)  // fractional ns
+        if let hb = tzHourByte, let mb = tzMinuteByte {
+            buffer.writeInteger(hb)
+            buffer.writeInteger(mb)
+        }
+        return buffer
+    }
 
-        let decoded = try Date(from: &buffer, type: .timestampTZ, context: .default)
-
+    private var expectedApril26Noon2025UTC: Date {
         var utc = Calendar(identifier: .gregorian)
         utc.timeZone = TimeZone(secondsFromGMT: 0)!
-        let expected = utc.date(from: DateComponents(
+        return utc.date(from: DateComponents(
             calendar: utc, timeZone: TimeZone(secondsFromGMT: 0),
             year: 2025, month: 4, day: 26, hour: 12, minute: 0, second: 0, nanosecond: 0
         ))!
-        #expect(decoded == expected)
     }
 
-    @Test func roundTripDateThroughTimestampTZWithNegativeLocalOffset() throws {
-        // Encoding a Date when the current timezone has a negative offset must not trap.
-        // We can't force the process timezone here, so we instead exercise the encoder math
-        // for a known-bad pair (hours = -7, minutes = 0): pre-fix this trapped on UInt8(-7).
-        let hours = -7
-        let minutes = 0
-        var buffer = ByteBuffer()
-        buffer.writeInteger(UInt8(hours + Int(Constants.TZ_HOUR_OFFSET)))
-        buffer.writeInteger(UInt8(minutes + Int(Constants.TZ_MINUTE_OFFSET)))
-        #expect(buffer.readableBytes == 2)
+    /// Regression: pre-fix, decoding a TIMESTAMP TZ with a negative UTC offset trapped on
+    /// `UInt8(byte11) - UInt8(20)` underflow inside `Date.init(from:type:context:)`.
+    @Test(arguments: [
+        // (offset description, tzHour, tzMinute)
+        ("-07:00 (PST/MST)", -7, 0),
+        ("-05:00 (EST)", -5, 0),
+        ("-12:00 (Baker Island)", -12, 0),
+        ("-03:30 (Newfoundland std)", -3, -30),
+    ])
+    func decodeTimestampTZWithNegativeOffset(
+        _ label: String, tzHour: Int, tzMinute: Int
+    ) throws {
+        let hourByte = UInt8(tzHour + Int(Constants.TZ_HOUR_OFFSET))
+        let minuteByte = UInt8(tzMinute + Int(Constants.TZ_MINUTE_OFFSET))
+        var buffer = makeTimestampBuffer(tzHourByte: hourByte, tzMinuteByte: minuteByte)
+
+        let decoded = try Date(from: &buffer, type: .timestampTZ, context: .default)
+        #expect(decoded == expectedApril26Noon2025UTC, "offset \(label)")
+    }
+
+    /// Sanity: positive offsets continue to decode correctly after the Int-promotion fix.
+    @Test(arguments: [
+        ("+00:00 (UTC)", 0, 0),
+        ("+05:30 (IST)", 5, 30),
+        ("+09:00 (JST)", 9, 0),
+        ("+14:00 (Kiribati)", 14, 0),
+    ])
+    func decodeTimestampTZWithPositiveOffset(
+        _ label: String, tzHour: Int, tzMinute: Int
+    ) throws {
+        let hourByte = UInt8(tzHour + Int(Constants.TZ_HOUR_OFFSET))
+        let minuteByte = UInt8(tzMinute + Int(Constants.TZ_MINUTE_OFFSET))
+        var buffer = makeTimestampBuffer(tzHourByte: hourByte, tzMinuteByte: minuteByte)
+
+        // For +00:00 both TZ bytes equal their offsets and the decoder skips the TZ branch
+        // (`byte11 != 0 && byte12 != 0` guard). The result must still be the UTC instant.
+        let decoded = try Date(from: &buffer, type: .timestampTZ, context: .default)
+        #expect(decoded == expectedApril26Noon2025UTC, "offset \(label)")
+    }
+
+    /// TIMESTAMP WITH LOCAL TIME ZONE travels the same code path; cover it explicitly so
+    /// the negative-offset fix is exercised for both wire types.
+    @Test func decodeTimestampLTZWithNegativeOffset() throws {
+        let hourByte = UInt8(-7 + Int(Constants.TZ_HOUR_OFFSET))
+        let minuteByte = UInt8(0 + Int(Constants.TZ_MINUTE_OFFSET))
+        var buffer = makeTimestampBuffer(tzHourByte: hourByte, tzMinuteByte: minuteByte)
+        let decoded = try Date(from: &buffer, type: .timestampLTZ, context: .default)
+        #expect(decoded == expectedApril26Noon2025UTC)
+    }
+
+    /// Plain TIMESTAMP (no TZ) — 11-byte buffer, no trailing offset bytes. Ensures the fix
+    /// did not break the path that skips the TZ branch entirely.
+    @Test func decodeTimestampWithoutTimeZone() throws {
+        var buffer = makeTimestampBuffer(tzHourByte: nil, tzMinuteByte: nil)
+        let decoded = try Date(from: &buffer, type: .timestamp, context: .default)
+        #expect(decoded == expectedApril26Noon2025UTC)
     }
 
     @Test func decodeDifferentNumericsFromARow() throws {


### PR DESCRIPTION
## Summary

The `Date` codec for `TIMESTAMP WITH TIME ZONE` / `TIMESTAMP WITH LOCAL TIME ZONE` performs `UInt8` arithmetic on the trailing two timezone bytes. For any value whose stored offset has a negative hour or minute component (e.g. `-07:00`, `-05:00`, `-03:30`), the subtraction underflows and traps with `EXC_BAD_INSTRUCTION` / `SIGTRAP`. Because the trap is a Swift runtime error, callers' `try?` cannot catch it — it crashes the process.

The same class of bug exists symmetrically on the encode path (`UInt8(hours)` and `UInt8(minutes)` trap when the local timezone has a negative offset).

## Reproduction

A real-world report: running `SELECT * FROM cloud_providers ORDER BY 1` in a third-party Swift client against a row whose `TIMESTAMP(6) WITH LOCAL TIME ZONE` column was inserted from a `-07:00` session crashed during cell decoding. The Oracle wire layout encodes `tz_hour = -7` as `byte11 = -7 + 20 = 13`. The decoder then computed `Int(byte11 - Constants.TZ_HOUR_OFFSET)` — i.e. `13 - 20` on `UInt8` — which underflows.

## Fix

Promote both operands to `Int` before the offset arithmetic on the decode path, and add the offset before narrowing to `UInt8` on the encode path.

\`\`\`swift
// Before (decode, lines 126–127)
let tzHour = Int(byte11 - Constants.TZ_HOUR_OFFSET)
let tzMinute = Int(byte12 - Constants.TZ_MINUTE_OFFSET)

// After
let tzHour = Int(byte11) - Int(Constants.TZ_HOUR_OFFSET)
let tzMinute = Int(byte12) - Int(Constants.TZ_MINUTE_OFFSET)
\`\`\`

\`\`\`swift
// Before (encode, lines 73–74)
buffer.writeInteger(UInt8(hours) + Constants.TZ_HOUR_OFFSET)
buffer.writeInteger(UInt8(minutes) + Constants.TZ_MINUTE_OFFSET)

// After
buffer.writeInteger(UInt8(hours + Int(Constants.TZ_HOUR_OFFSET)))
buffer.writeInteger(UInt8(minutes + Int(Constants.TZ_MINUTE_OFFSET)))
\`\`\`

## Tests

Added parameterized regressions in `OracleCodableTests` that build wire buffers with known offset bytes and assert the decoded `Date` matches the expected UTC instant. Coverage:

- `decodeTimestampTZWithNegativeOffset` — `-07:00`, `-05:00`, `-12:00`, `-03:30`
- `decodeTimestampTZWithPositiveOffset` — `+00:00`, `+05:30`, `+09:00`, `+14:00`
- `decodeTimestampLTZWithNegativeOffset` — `-07:00` on the LTZ wire type
- `decodeTimestampWithoutTimeZone` — 11-byte buffer, ensures the no-TZ branch is unaffected

## Evidence

### Before the fix (test process traps)

\`\`\`
Test Suite 'oracle-nioPackageTests.xctest' started at 2026-04-26 15:04:53.271
􀟈  Test run started.
􀟈  Suite OracleCodableTests started.
􀟈  Test decodeTimestampTZWithNegativeOffset(_:tzHour:tzMinute:) started.
􀟈  Test case "-07:00 (PST/MST)", tzHour → -7 …
􀟈  Test case "-05:00 (EST)", tzHour → -5 …
􀟈  Test case "-12:00 (Baker Island)", tzHour → -12 …
􀟈  Test case "-03:30 (Newfoundland std)", tzHour → -3, tzMinute → -30 …
error: Process '… oracle-nioPackageTests' exited with unexpected signal code 5
\`\`\`

No `passed` markers are emitted for the negative-offset cases — the whole process aborts on the `UInt8` underflow trap.

### After the fix (all green, ~1ms)

\`\`\`
􀟈  Test run started.
􀟈  Suite OracleCodableTests started.
􁁛  Test decodeTimestampLTZWithNegativeOffset() passed after 0.001 seconds.
􁁛  Test decodeTimestampTZWithNegativeOffset(_:tzHour:tzMinute:) with 4 test cases passed after 0.001 seconds.
􁁛  Test decodeTimestampWithoutTimeZone() passed after 0.001 seconds.
􁁛  Test decodeTimestampTZWithPositiveOffset(_:tzHour:tzMinute:) with 4 test cases passed after 0.001 seconds.
􁁛  Suite OracleCodableTests passed after 0.001 seconds.
􁁛  Test run with 4 tests in 1 suite passed after 0.001 seconds.
\`\`\`

## Notes

- The decoded `Date` instant is identical regardless of offset sign — Swift's `Date` carries no timezone, so `21:28 -07:00` decodes to the same instant as `04:28 UTC` (consistent with the existing decoder's intent to return the absolute UTC moment). The fix is purely about avoiding the `UInt8` trap; semantics of the returned value are unchanged.
- The encode-side fix is included for symmetry — pre-fix, encoding any `Date` while the process timezone has a negative offset would also trap.