### PR TITLE
Fix BitVector.decode silently swallowing partial reads

### DIFF
--- a/Sources/OracleNIO/Messages/OracleBackendMessage+BitVector.swift
+++ b/Sources/OracleNIO/Messages/OracleBackendMessage+BitVector.swift
@@ -33,7 +33,16 @@ extension OracleBackendMessage {
             if columnsCount % 8 > 0 {
                 length += 1
             }
-            let bitVector = buffer.readBytes(length: length)
+            // The bitVector content can straddle a TNS packet boundary. When
+            // it does, `readBytes` returns nil — we must surface that as a
+            // partial-decode trigger so the decoder saves a partial and
+            // resumes once the next packet arrives. Returning silently with
+            // `bitVector = nil` leaves the unread content as the head of the
+            // next packet, where the decoder misreads it as a fresh
+            // messageID and crashes deep in QueryParameter.decode.
+            guard let bitVector = buffer.readBytes(length: length) else {
+                throw MissingDataDecodingError.Trigger()
+            }
             return .init(
                 columnsCountSent: UInt16(columnsCountSent),
                 bitVector: bitVector

--- a/Tests/IntegrationTests/BugReportTests.swift
+++ b/Tests/IntegrationTests/BugReportTests.swift
@@ -202,6 +202,65 @@ final class BugReportTests: IntegrationTest {
             ).self)
         {}
     }
+
+    /// Regression test for the BitVector partial-decode crash.
+    ///
+    /// Adjacent rows share the leading column so the server emits a per-row
+    /// BitVector marking it duplicate. Payload length cycles 1..4000 so the
+    /// cumulative byte stream sweeps every alignment within the SDU window —
+    /// that guarantees at least one TNS packet boundary lands inside a
+    /// BitVector message. Pre-fix this crashes deep in `ByteBuffer.readUB2`
+    /// (`preconditionFailure`) because the bitVector content byte is left
+    /// at the head of the next packet and read as a fresh messageID.
+    /// Post-fix every row decodes cleanly.
+    @Test func selectWithBitVectorContentAcrossPacketBoundary() async throws {
+        _ = try? await connection.execute("DROP TABLE bv_repro", logger: .oracleTest)
+        try await connection.execute(
+            """
+            CREATE TABLE bv_repro (
+                grp varchar2(30),
+                seq number,
+                payload varchar2(4000)
+            )
+            """,
+            logger: .oracleTest
+        )
+
+        let totalRows = 20_000
+        try await connection.execute(
+            """
+            BEGIN
+                FOR i IN 0..\(unescaped: String(totalRows - 1)) LOOP
+                    INSERT INTO bv_repro VALUES (
+                        'grp_' || LPAD(TRUNC(i / 100), 3, '0'),
+                        i,
+                        RPAD('x', MOD(i, 4000) + 1, 'x')
+                    );
+                END LOOP;
+                COMMIT;
+            END;
+            """,
+            logger: .oracleTest
+        )
+
+        var options = StatementOptions()
+        options.prefetchRows = 100_000
+        options.arraySize = 1000
+        let stream = try await connection.execute(
+            "SELECT grp, seq, payload FROM bv_repro ORDER BY grp, seq",
+            options: options,
+            logger: .oracleTest
+        )
+
+        var seen = 0
+        for try await row in stream.decode((String, Int, String).self) {
+            #expect(row.0.hasPrefix("grp_"))
+            seen += 1
+        }
+        #expect(seen == totalRows)
+
+        try await connection.execute("DROP TABLE bv_repro", logger: .oracleTest)
+    }
 }
 
 /// A Oracle Timestamp which is equivalent to a `Date` without caring about its `TimeZone`.

--- a/Tests/OracleNIOTests/Messages/BitVectorTests.swift
+++ b/Tests/OracleNIOTests/Messages/BitVectorTests.swift
@@ -1,0 +1,41 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the OracleNIO open source project
+//
+// Copyright (c) 2024 Timo Zacherl and the OracleNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of OracleNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOCore
+import Testing
+
+@testable import OracleNIO
+
+private typealias BitVector = OracleBackendMessage.BitVector
+
+@Suite(.timeLimit(.minutes(5))) struct BitVectorTests {
+
+    /// Simulates a TNS packet that ends between the bitVector header and its
+    /// trailing content byte. With 4 columns the content is `ceil(4 / 8) = 1`
+    /// byte; the buffer carries only the `columnsCountSent` UB2 (`01 01`).
+    /// Pre-fix this returned silently with `bitVector = nil`; post-fix it
+    /// throws `Trigger` so the decoder saves a partial and resumes on the
+    /// next packet.
+    @Test func decodeRequestsMissingDataWhenContentTruncated() {
+        var buffer = ByteBuffer(bytes: [0x01, 0x01])  // columnsCountSent UB2 only
+        #expect(
+            throws: MissingDataDecodingError.Trigger(),
+            performing: {
+                try BitVector.decode(
+                    from: &buffer,
+                    context: .init(columns: .number, .number, .number, .number)
+                )
+            })
+    }
+}


### PR DESCRIPTION
# Fix BitVector.decode silently swallowing partial reads

## Summary

`BitVector.decode` calls `buffer.readBytes(length:)` for the bitVector content
and assigns the result directly to a `[UInt8]?` without reacting to `nil`.
When the bitVector content straddles a TNS packet boundary, that `nil` is
treated as a successful (empty/absent) bitVector. The decoder advances past
the message and the unread content byte is left at the head of the next
packet, where it is misread as a fresh `messageID` and dispatched as a new
message — causing a downstream crash deep in `QueryParameter.decode` (a
`preconditionFailure()` in `ByteBuffer.readUB2()` because the byte after the
ID is a length value out of range for UB2).

The fix throws `MissingDataDecodingError.Trigger()` when `readBytes` returns
`nil`, so the caller saves a partial and resumes once the next packet
arrives — the same pattern used elsewhere in the decoder (e.g.
`RowData.processColumnData`).

## How I hit it

Repeatedly running a `dba_source` query that orders by `(type, owner, name,
line)` against a busy database. Adjacent rows for the same package share
`type/owner/name`, so the server emits short bitVector messages of the form
`15 01 01 08` (id, columnsCountSent UB2, 1-byte bitVector content) marking
those three columns as duplicates. With `prefetchRows` set high enough that
responses pack into multiple SDU-sized TNS packets, eventually a packet
boundary lands between bytes 3 and 4 of one of those bitVector messages
(after the UB2, before the content). On that boundary the buggy path fires:

```
[oracle-nio diag] decode(.data) entry readable=8102 head=07 14 ... END IF;\n 15 01
[oracle-nio diag] decode(.data) entry readable=8101 head=08 07 2f ... ELSIF v_par...
OracleNIO/ByteBuffer+UB.swift:42: Fatal error
```

The `08` at the head of the second packet is the bitVector content byte the
server sent; the decoder treats it as `MessageID.parameter` (= 8), dispatches
to `QueryParameter.decode`, reads the next byte (`07`) as a UB2 length, and
crashes.

Stack at crash:
```
#0  preconditionFailure
#1  ByteBuffer.readUB2()  (ByteBuffer+UB.swift:42)
#2  OracleBackendMessage.QueryParameter.decode  (OracleBackendMessage+Parameter.swift:73)
#3  OracleBackendMessage.decodeData
#4  OracleBackendMessage.decode
#5  OracleBackendMessageDecoder.decodeMessage0
```

## Fix

```diff
-            let bitVector = buffer.readBytes(length: length)
+            // The bitVector content can straddle a TNS packet boundary. When
+            // it does, `readBytes` returns nil — we must surface that as a
+            // partial-decode trigger so the decoder saves a partial and
+            // resumes once the next packet arrives. Returning silently with
+            // `bitVector = nil` leaves the unread content as the head of the
+            // next packet, where the decoder misreads it as a fresh
+            // messageID and crashes deep in QueryParameter.decode.
+            guard let bitVector = buffer.readBytes(length: length) else {
+                throw MissingDataDecodingError.Trigger()
+            }
             return .init(
                 columnsCountSent: UInt16(columnsCountSent),
                 bitVector: bitVector
             )
```

## Tests

### 1. Unit test — pinpoint the decoder behavior change

Drop into `Tests/OracleNIOTests/Messages/BitVectorTests.swift` (mirrors the
shape of `RowDataTests.processVectorColumnDataRequestsMissingData` and
relies on the existing `OracleBackendMessageDecoder+TestUtils` convenience
init):

```swift
//===----------------------------------------------------------------------===//
//
// This source file is part of the OracleNIO open source project
//
// Copyright (c) 2024 Timo Zacherl and the OracleNIO project authors
// Licensed under Apache License v2.0
//
// See LICENSE for license information
// See CONTRIBUTORS.md for the list of OracleNIO project authors
//
// SPDX-License-Identifier: Apache-2.0
//
//===----------------------------------------------------------------------===//

import NIOCore
import Testing

@testable import OracleNIO

private typealias BitVector = OracleBackendMessage.BitVector

@Suite(.timeLimit(.minutes(5))) struct BitVectorTests {

    /// Simulates a TNS packet that ends between the bitVector header and its
    /// trailing content byte. With 4 columns the content is `ceil(4/8) = 1`
    /// byte; the buffer carries only the `columnsCountSent` UB2 (`01 01`).
    /// Pre-fix this returned silently with `bitVector = nil`; post-fix it
    /// throws `Trigger` so the decoder saves a partial and resumes on the
    /// next packet.
    @Test func decodeRequestsMissingDataWhenContentTruncated() {
        var buffer = ByteBuffer(bytes: [0x01, 0x01])  // columnsCountSent UB2 only
        #expect(
            throws: MissingDataDecodingError.Trigger(),
            performing: {
                try BitVector.decode(
                    from: &buffer,
                    context: .init(columns: .number, .number, .number, .number)
                )
            })
    }
}
```

Without the fix the test passes through `BitVector.decode` returning a value
with `bitVector = nil` (no error); with the fix it throws
`MissingDataDecodingError.Trigger`, which the existing `decodeData` catch
clause converts into a `MissingDataDecodingError` whose `resetToReaderIndex`
points back to the bitVector message ID — `decodeMessage0` then captures
the partial and waits for the next packet, which is the correct behavior.

### 2. End-to-end test against a real Oracle — answers the "how does any query work?" question

Drop into `Tests/IntegrationTests/BugReportTests.swift`. Builds a table where
adjacent rows share a leading column (so the server emits per-row
BitVectors marking it duplicate), pads the trailing column with varied
sizes so the cumulative byte stream straddles many SDU boundaries, and
issues a SELECT with a high `prefetchRows` so the response packs into
multiple TNS packets. With the parameters below, on a default 8 KB SDU
the response is on the order of ~1000 packets, which reliably places at
least one packet boundary in the middle of a BitVector message — pre-fix
this crashes with `preconditionFailure` in `ByteBuffer.readUB2()`;
post-fix every row decodes:

```swift
@Test func selectWithBitVectorContentAcrossPacketBoundary() async throws {
    _ = try? await connection.execute("DROP TABLE bv_repro", logger: .oracleTest)
    try await connection.execute(
        """
        CREATE TABLE bv_repro (
            grp varchar2(30),
            seq number,
            payload varchar2(4000)
        )
        """,
        logger: .oracleTest
    )

    // Adjacent rows share `grp`, so the server emits a per-row BitVector
    // marking it duplicate. Payload length cycles 1..4000 so the cumulative
    // byte stream sweeps every alignment inside the SDU window — that
    // guarantees at least one TNS packet boundary lands inside a BitVector
    // message.
    let totalRows = 20_000
    try await connection.execute(
        """
        BEGIN
            FOR i IN 0..\(unescaped: String(totalRows - 1)) LOOP
                INSERT INTO bv_repro VALUES (
                    'grp_' || LPAD(TRUNC(i / 100), 3, '0'),
                    i,
                    RPAD('x', MOD(i, 4000) + 1, 'x')
                );
            END LOOP;
            COMMIT;
        END;
        """,
        logger: .oracleTest
    )

    var options = StatementOptions()
    options.prefetchRows = 100_000
    options.arraySize = 1000
    let stream = try await connection.execute(
        "SELECT grp, seq, payload FROM bv_repro ORDER BY grp, seq",
        options: options,
        logger: .oracleTest
    )

    var seen = 0
    for try await row in stream.decode((String, Int, String).self) {
        // Cheap sanity — the duplicate column must round-trip intact.
        #expect(row.0.hasPrefix("grp_"))
        seen += 1
    }
    #expect(seen == totalRows)

    try await connection.execute("DROP TABLE bv_repro", logger: .oracleTest)
}
```

I ran this against a local Oracle (Free 23ai, default 8 KB SDU):

- **Pre-fix** (revert just the `guard … else { throw … }` block): test crashes
  with `OracleNIO/ByteBuffer+UB.swift:200: Fatal error` (`preconditionFailure`
  in `skipUB`, exit signal 5 — SIGTRAP).
- **Post-fix**: test passes in ~1.3 s, all 20 000 rows round-trip.

Why most queries don't hit this: the bug only fires when the 1-byte
bitVector content lands as the *very last* byte of a TNS packet. Most
SELECTs don't emit BitVectors at all (no adjacent rows with duplicate
columns), or the response fits in a single packet, or the boundary lands
elsewhere. Real-world report that surfaced this: a SELECT against `dba_source`
ordered by `(type, owner, name, line)` over thousands of rows with
`prefetchRows = 50_000` — the same shape this test reproduces.

## Notes / follow-ups

- I kept the `bitVector` field on `OracleBackendMessage.BitVector` as
  `[UInt8]?` to limit blast radius — callers (`context.bitVector` in
  `OracleBackendMessage.decodeData` and the `RowData` consumer in
  `StatementStateMachine`) already handle the `nil` case. Tightening that to
  non-optional would be a reasonable follow-up since the only path that
  produced `nil` is now removed.
- I haven't audited every other `readBytes(length:)` call site for the same
  pattern; this PR is intentionally scoped to the demonstrable crash. Worth
  a sweep in a follow-up.
