### PR TITLE
Crash-free decoding for unsupported types + INTERVAL YEAR TO MONTH

### DIFF
--- a/Sources/OracleNIO/Capabilities.swift
+++ b/Sources/OracleNIO/Capabilities.swift
@@ -26,6 +26,7 @@ struct Capabilities: Sendable, Hashable {
     var runtimeCapabilities = [UInt8](repeating: 0, count: Constants.TNS_RCAP_MAX)
     var supportsFastAuth = false
     var supportsOOB = false
+    var supportsOOBCheck = false
     var supportsEndOfRequest = false
     var maxStringSize: UInt32 = 0
     var sdu: UInt32 = UInt32(Constants.TNS_SDU)
@@ -69,10 +70,21 @@ struct Capabilities: Sendable, Hashable {
         self.compileCapabilities[Constants.TNS_CCAP_TTC2] = Constants.TNS_CCAP_ZLNP
         self.compileCapabilities[Constants.TNS_CCAP_OCI2] = Constants.TNS_CCAP_DRCP
         self.compileCapabilities[Constants.TNS_CCAP_CLIENT_FN] = Constants.TNS_CCAP_CLIENT_FN_MAX
-        self.compileCapabilities[Constants.TNS_CCAP_TTC4] = Constants.TNS_CCAP_INBAND_NOTIFICATION
-        self.compileCapabilities[Constants.TNS_CCAP_TTC5] = Constants.TNS_CCAP_VECTOR_SUPPORT
+        self.compileCapabilities[Constants.TNS_CCAP_QUEUE_OPTIONS] =
+            Constants.TNS_CCAP_DEQUEUE_WITH_SELECTOR
+        self.compileCapabilities[Constants.TNS_CCAP_OCI3] = Constants.TNS_CCAP_OCI3_OCSSYNC
+        self.compileCapabilities[Constants.TNS_CCAP_SESS_SIGNATURE_INDEX] =
+            Constants.TNS_CCAP_SESS_SIGNATURE_VERSION
+        self.compileCapabilities[Constants.TNS_CCAP_TTC4] =
+            Constants.TNS_CCAP_INBAND_NOTIFICATION | Constants.TNS_CCAP_TTC4_EXPLICIT_BOUNDARY
+        self.compileCapabilities[Constants.TNS_CCAP_TTC5] =
+            Constants.TNS_CCAP_VECTOR_SUPPORT | Constants.TNS_CCAP_TOKEN_SUPPORTED
+            | Constants.TNS_CCAP_PIPELINING_SUPPORT | Constants.TNS_CCAP_PIPELINING_BREAK
+            | Constants.TNS_CCAP_SESSIONLESS_TXNS
+        self.compileCapabilities[Constants.TNS_CCAP_FEATURE_BACKPORT2] =
+            Constants.TNS_CCAP_END_USER_SEC_CTX_PIGGYBACK
         self.compileCapabilities[Constants.TNS_CCAP_VECTOR_FEATURES] =
-            Constants.TNS_CCAP_VECTOR_FEATURE_BINARY
+            Constants.TNS_CCAP_VECTOR_FEATURE_BINARY | Constants.TNS_CCAP_VECTOR_FEATURE_SPARSE
 
         // Runtime Capabilities
         self.runtimeCapabilities[Constants.TNS_RCAP_COMPAT] = Constants.TNS_RCAP_COMPAT_81
@@ -91,6 +103,7 @@ struct Capabilities: Sendable, Hashable {
         self.runtimeCapabilities = .init(repeating: 0, count: Constants.TNS_RCAP_MAX)
         self.supportsFastAuth = try buffer.throwingReadInteger(as: UInt8.self) == 1
         self.supportsOOB = try buffer.throwingReadInteger(as: UInt8.self) == 1
+        self.supportsOOBCheck = try buffer.throwingReadInteger(as: UInt8.self) == 1
         self.supportsEndOfRequest = try buffer.throwingReadInteger(as: UInt8.self) == 1
         self.maxStringSize = try buffer.throwingReadInteger()
         self.sdu = try buffer.throwingReadInteger()
@@ -105,6 +118,7 @@ struct Capabilities: Sendable, Hashable {
         buffer.writeInteger(self.nCharsetID)
         buffer.writeInteger(UInt8(self.supportsFastAuth ? 1 : 0))
         buffer.writeInteger(UInt8(self.supportsOOB ? 1 : 0))
+        buffer.writeInteger(UInt8(self.supportsOOBCheck ? 1 : 0))
         buffer.writeInteger(UInt8(self.supportsEndOfRequest ? 1 : 0))
         buffer.writeInteger(self.maxStringSize)
         buffer.writeInteger(self.sdu)
@@ -117,6 +131,9 @@ struct Capabilities: Sendable, Hashable {
         self.supportsOOB = options & Constants.TNS_GSO_CAN_RECV_ATTENTION != 0
         if (flags & Constants.TNS_ACCEPT_FLAG_FAST_AUTH) != 0 {
             self.supportsFastAuth = true
+        }
+        if (flags & Constants.TNS_ACCEPT_FLAG_CHECK_OOB) != 0 {
+            self.supportsOOBCheck = true
         }
         if self.protocolVersion >= Constants.TNS_VERSION_MIN_END_OF_RESPONSE
             && (flags & Constants.TNS_ACCEPT_FLAG_HAS_END_OF_REQUEST) != 0

--- a/Sources/OracleNIO/ConnectionStateMachine/ConnectionStateMachine.swift
+++ b/Sources/OracleNIO/ConnectionStateMachine/ConnectionStateMachine.swift
@@ -393,6 +393,7 @@ struct ConnectionStateMachine {
         let capabilities = accept.newCapabilities
 
         if capabilities.supportsOOB
+            && capabilities.supportsOOBCheck
             && capabilities.protocolVersion >= Constants.TNS_VERSION_MIN_OOB_CHECK
         {
             self.state = .oobCheckInProgress(fastAuth: capabilities.supportsOOB)
@@ -1057,7 +1058,8 @@ extension ConnectionStateMachine {
             .serverVersionNotSupported,
             .sidNotSupported,
             .uncleanShutdown,
-            .unsupportedDataType:
+            .unsupportedDataType,
+            .unsupportedVerifierType:
             return true
         case .statementCancelled, .nationalCharsetNotSupported, .missingStatement, .malformedStatement:
             return false

--- a/Sources/OracleNIO/Constants.swift
+++ b/Sources/OracleNIO/Constants.swift
@@ -306,6 +306,7 @@ enum Constants {
     static let TNS_CCAP_FEATURE_BACKPORT = 5
     static let TNS_CCAP_FIELD_VERSION = 7
     static let TNS_CCAP_SERVER_DEFINE_CONV = 8
+    static let TNS_CCAP_QUEUE_OPTIONS = 9
     static let TNS_CCAP_TTC1 = 15
     static let TNS_CCAP_OCI1 = 16
     static let TNS_CCAP_TDS_VERSION = 17
@@ -317,10 +318,13 @@ enum Constants {
     static let TNS_CCAP_UB2_DTY = 27
     static let TNS_CCAP_OCI2 = 31
     static let TNS_CCAP_CLIENT_FN = 34
+    static let TNS_CCAP_OCI3 = 35
     static let TNS_CCAP_TTC3 = 37
+    static let TNS_CCAP_SESS_SIGNATURE_INDEX = 39
     static let TNS_CCAP_TTC4 = 40
     static let TNS_CCAP_LOB2 = 42
     static let TNS_CCAP_TTC5 = 44
+    static let TNS_CCAP_FEATURE_BACKPORT2 = 45
     static let TNS_CCAP_VECTOR_FEATURES = 52
     static let TNS_CCAP_MAX = 53
 
@@ -392,13 +396,27 @@ enum Constants {
     static let TNS_RCAP_TTC_32K: UInt8 = 0x04
 
     // MARK: Verifier types
+    static let TNS_VERIFIER_TYPE_10G: UInt32 = 0x939
     static let TNS_VERIFIER_TYPE_11G_1: UInt32 = 0xb152
     static let TNS_VERIFIER_TYPE_11G_2: UInt32 = 0x1b25
     static let TNS_VERIFIER_TYPE_12C: UInt32 = 0x4815
 
     // MARK: Accept flags
+    static let TNS_ACCEPT_FLAG_CHECK_OOB: UInt32 = 0x0000_0001
     static let TNS_ACCEPT_FLAG_FAST_AUTH: UInt32 = 0x1000_0000
     static let TNS_ACCEPT_FLAG_HAS_END_OF_REQUEST: UInt32 = 0x0200_0000
+
+    // MARK: 23ai compile capability flags
+    static let TNS_CCAP_DEQUEUE_WITH_SELECTOR: UInt8 = 0x01
+    static let TNS_CCAP_OCI3_OCSSYNC: UInt8 = 0x20
+    static let TNS_CCAP_TTC4_EXPLICIT_BOUNDARY: UInt8 = 0x40
+    static let TNS_CCAP_TOKEN_SUPPORTED: UInt8 = 0x02
+    static let TNS_CCAP_PIPELINING_SUPPORT: UInt8 = 0x04
+    static let TNS_CCAP_PIPELINING_BREAK: UInt8 = 0x08
+    static let TNS_CCAP_SESSIONLESS_TXNS: UInt8 = 0x10
+    static let TNS_CCAP_SESS_SIGNATURE_VERSION: UInt8 = 8
+    static let TNS_CCAP_END_USER_SEC_CTX_PIGGYBACK: UInt8 = 0x02
+    static let TNS_CCAP_VECTOR_FEATURE_SPARSE: UInt8 = 0x02
 
     // MARK: Other constants
     @usableFromInline

--- a/Sources/OracleNIO/Data/IntervalYM+OracleCodable.swift
+++ b/Sources/OracleNIO/Data/IntervalYM+OracleCodable.swift
@@ -1,0 +1,93 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the OracleNIO open source project
+//
+// Copyright (c) 2026 Timo Zacherl and the OracleNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of OracleNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOCore
+
+public struct IntervalYM: Sendable, Equatable, Hashable {
+    public var years: Int
+    public var months: Int
+
+    @inlinable
+    public init(years: Int, months: Int) {
+        self.years = years
+        self.months = months
+    }
+}
+
+extension IntervalYM: ExpressibleByIntegerLiteral {
+    @inlinable
+    public init(integerLiteral value: Int) {
+        self.init(years: value / 12, months: value % 12)
+    }
+
+    @inlinable
+    public var totalMonths: Int {
+        years * 12 + months
+    }
+}
+
+extension IntervalYM: Encodable {
+    @inlinable
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(totalMonths)
+    }
+}
+
+extension IntervalYM: Decodable {
+    @inlinable
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let total = try container.decode(Int.self)
+        self = .init(years: total / 12, months: total % 12)
+    }
+}
+
+extension IntervalYM: OracleEncodable {
+    @inlinable
+    public static var defaultOracleType: OracleDataType { .intervalYM }
+
+    @inlinable
+    public func encode(
+        into buffer: inout ByteBuffer,
+        context: OracleEncodingContext
+    ) {
+        let biasedYears = UInt32(bitPattern: Int32(years)) &+ 0x8000_0000
+        buffer.writeInteger(biasedYears, endianness: .big)
+        buffer.writeInteger(UInt8(months + 60))
+    }
+}
+
+extension IntervalYM: OracleDecodable {
+    @inlinable
+    public init(
+        from buffer: inout ByteBuffer,
+        type: OracleDataType,
+        context: OracleDecodingContext
+    ) throws {
+        switch type {
+        case .intervalYM:
+            guard buffer.readableBytes >= 5 else {
+                throw OracleDecodingError.Code.missingData
+            }
+            let biasedYears = try buffer.throwingReadInteger(endianness: .big, as: UInt32.self)
+            let monthsByte = try buffer.throwingReadInteger(as: UInt8.self)
+            let years = Int(Int32(bitPattern: biasedYears &- 0x8000_0000))
+            let months = Int(monthsByte) - 60
+            self = .init(years: years, months: months)
+        default:
+            throw OracleDecodingError.Code.typeMismatch
+        }
+    }
+}

--- a/Sources/OracleNIO/Helper/Oracle10GHash.swift
+++ b/Sources/OracleNIO/Helper/Oracle10GHash.swift
@@ -1,0 +1,79 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the OracleNIO open source project
+//
+// Copyright (c) 2026 Timo Zacherl and the OracleNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of OracleNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(CommonCrypto)
+import CommonCrypto
+#endif
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+/// Oracle 10G "O5LOGON" password hash used for accounts whose
+/// `password_versions` includes a 10G verifier.
+///
+/// Two-pass DES-CBC over UTF-16BE(uppercase(username + password)) padded to an
+/// 8-byte boundary. First pass uses Oracle's published fixed key; the last
+/// 8 bytes of its ciphertext become the second-pass key. The 8-byte hash is
+/// the last 8 bytes of the second-pass ciphertext.
+///
+/// Reference test vector: `username` / `password` -> `872805F3F4C83365`.
+public enum Oracle10GHash {
+    static let initialKey: [UInt8] = [0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef]
+
+    public static func compute(username: String, password: String) -> [UInt8] {
+        let posix = Locale(identifier: "en_US_POSIX")
+        let combined = (username + password).uppercased(with: posix)
+        let utf16 = combined.data(using: .utf16BigEndian) ?? Data()
+        var padded = [UInt8](utf16)
+        let remainder = padded.count % 8
+        if remainder != 0 {
+            padded.append(contentsOf: [UInt8](repeating: 0, count: 8 - remainder))
+        }
+        let pass1 = desCBCEncrypt(key: initialKey, plaintext: padded)
+        let key2 = Array(pass1.suffix(8))
+        let pass2 = desCBCEncrypt(key: key2, plaintext: padded)
+        return Array(pass2.suffix(8))
+    }
+}
+
+#if canImport(CommonCrypto)
+@usableFromInline
+func desCBCEncrypt(key: [UInt8], plaintext: [UInt8]) -> [UInt8] {
+    precondition(key.count == 8, "DES key must be 8 bytes")
+    precondition(plaintext.count % 8 == 0, "DES-CBC plaintext must be multiple of 8 bytes")
+    let iv = [UInt8](repeating: 0, count: 8)
+    var output = [UInt8](repeating: 0, count: plaintext.count + 8)
+    var produced: size_t = 0
+    let status = CCCrypt(
+        CCOperation(kCCEncrypt),
+        CCAlgorithm(kCCAlgorithmDES),
+        CCOptions(0),
+        key, key.count,
+        iv,
+        plaintext, plaintext.count,
+        &output, output.count,
+        &produced
+    )
+    precondition(status == kCCSuccess, "CCCrypt(DES-CBC) failed with status \(status)")
+    return Array(output.prefix(produced))
+}
+#else
+@usableFromInline
+func desCBCEncrypt(key: [UInt8], plaintext: [UInt8]) -> [UInt8] {
+    fatalError("DES-CBC unavailable on this platform; oracle-nio 10G auth requires CommonCrypto (Apple platforms)")
+}
+#endif

--- a/Sources/OracleNIO/Messages/Coding/OracleFrontendMessageEncoder.swift
+++ b/Sources/OracleNIO/Messages/Coding/OracleFrontendMessageEncoder.swift
@@ -23,6 +23,15 @@ import NIOCore
     import Foundation
 #endif
 
+/// The Oracle password verifier scheme negotiated during authentication.
+/// Determines hash derivation, AES key length, and which AUTH_PBKDF2_*
+/// parameters are required.
+enum VerifierKind: Sendable, Equatable {
+    case tenG
+    case elevenG
+    case twelveC
+}
+
 struct OracleFrontendMessageEncoder {
     static let headerSize = 8
 
@@ -294,11 +303,11 @@ struct OracleFrontendMessageEncoder {
             from: authContext.mode, method: authContext.method
         )
 
-        let verifier11g: Bool
+        let verifierKind: VerifierKind
         switch authContext.method.base {
         case .token(let token):
             numberOfPairs += 1
-            verifier11g = false  // ignored
+            verifierKind = .twelveC  // ignored for token auth
 
             switch token.base {
             case .oAuth2: break
@@ -309,16 +318,16 @@ struct OracleFrontendMessageEncoder {
             numberOfPairs += 2
             authMode |= Constants.TNS_AUTH_MODE_WITH_PASSWORD
 
-            if [
-                Constants.TNS_VERIFIER_TYPE_11G_1,
-                Constants.TNS_VERIFIER_TYPE_11G_2,
-            ].contains(verifierType) {
-                verifier11g = true
-            } else if verifierType != Constants.TNS_VERIFIER_TYPE_12C {
-                throw OracleSQLError.serverVersionNotSupported
-            } else {
-                verifier11g = false
+            switch verifierType {
+            case Constants.TNS_VERIFIER_TYPE_10G:
+                verifierKind = .tenG
+            case Constants.TNS_VERIFIER_TYPE_11G_1, Constants.TNS_VERIFIER_TYPE_11G_2:
+                verifierKind = .elevenG
+            case Constants.TNS_VERIFIER_TYPE_12C:
+                verifierKind = .twelveC
                 numberOfPairs += 1
+            default:
+                throw OracleSQLError.unsupportedVerifierType(verifierType ?? 0)
             }
 
             // determine which other key/value pairs to write
@@ -381,15 +390,16 @@ struct OracleFrontendMessageEncoder {
             }
             comboKey = nil
 
-        case .usernamePassword(_, let password, let newPassword):
+        case .usernamePassword(let username, let password, let newPassword):
 
             let (
                 sessionKey, speedyKey, encodedPassword, encodedNewPassword, _comboKey
             ) = try Self.generateVerifier(
+                username: username,
                 password: password,
                 newPassword: newPassword,
                 parameters: parameters,
-                verifier11g
+                kind: verifierKind
             )
             comboKey = _comboKey
 
@@ -397,7 +407,7 @@ struct OracleFrontendMessageEncoder {
                 key: "AUTH_SESSKEY", value: sessionKey, flags: 1
             )
             self.writeKeyValuePair(key: "AUTH_PASSWORD", value: encodedPassword)
-            if !verifier11g {
+            if verifierKind == .twelveC {
                 guard let speedyKey else {
                     preconditionFailure(
                         """
@@ -883,10 +893,11 @@ extension OracleFrontendMessageEncoder {
     }
 
     private static func generateVerifier(
+        username: String,
         password: String,
         newPassword: String?,
         parameters: OracleBackendMessage.Parameter,
-        _ verifier11g: Bool
+        kind: VerifierKind
     ) throws -> (
         sessionKey: String,
         speedyKey: String?,
@@ -912,14 +923,23 @@ extension OracleFrontendMessageEncoder {
         // create password hash
         let passwordHash: [UInt8]
         let passwordKey: [UInt8]?
-        if verifier11g {
+        switch kind {
+        case .tenG:
+            keyLength = 24
+            let tenGHash = Oracle10GHash.compute(
+                username: username,
+                password: String(decoding: password, as: UTF8.self)
+            )
+            passwordHash = tenGHash + [UInt8](repeating: 0, count: 16)
+            passwordKey = nil
+        case .elevenG:
             keyLength = 24
             var sha = Insecure.SHA1()
             sha.update(data: password)
             sha.update(data: verifierData)
             passwordHash = sha.finalize() + [UInt8](repeating: 0, count: 4)
             passwordKey = nil
-        } else {
+        case .twelveC:
             keyLength = 32
             guard
                 let vgenCountStr = parameters["AUTH_PBKDF2_VGEN_COUNT"],
@@ -982,8 +1002,8 @@ extension OracleFrontendMessageEncoder {
             salt: mixingSalt, length: keyLength, iterations: iterations
         )
 
-        // generate speedy key for 12c verifiers
-        if !verifier11g, let passwordKey {
+        // generate speedy key for 12c verifiers only
+        if kind == .twelveC, let passwordKey {
             let salt = [UInt8].random(count: 16)
             let speedyKeyCBC = try encryptCBC(comboKey, salt + passwordKey)
             speedyKey = speedyKeyCBC.prefix(80).hexString.uppercased()

--- a/Sources/OracleNIO/Messages/Coding/OraclePartialDecodingError.swift
+++ b/Sources/OracleNIO/Messages/Coding/OraclePartialDecodingError.swift
@@ -19,6 +19,7 @@ struct OraclePartialDecodingError: Error {
         case expectedAtLeastNRemainingBytes
         case fieldNotDecodable
         case unsupportedDataType
+        case columnTruncated
         case unknownMessageID
         case unknownControlType
     }
@@ -72,6 +73,16 @@ struct OraclePartialDecodingError: Error {
         OraclePartialDecodingError(
             category: .unsupportedDataType,
             description: "Could not process unsupported data type '\(type)'.",
+            file: file, line: line
+        )
+    }
+
+    static func columnTruncated(
+        length: Int, file: String = #fileID, line: Int = #line
+    ) -> Self {
+        OraclePartialDecodingError(
+            category: .columnTruncated,
+            description: "Column truncated, length: \(length).",
             file: file, line: line
         )
     }

--- a/Sources/OracleNIO/Messages/OracleBackendMessage+RowData.swift
+++ b/Sources/OracleNIO/Messages/OracleBackendMessage+RowData.swift
@@ -125,7 +125,7 @@ extension OracleBackendMessage {
             switch oracleType {
             case .varchar, .char, .long, .raw, .longRAW, .number, .date, .timestamp,
                 .timestampLTZ, .timestampTZ, .binaryDouble, .binaryFloat,
-                .binaryInteger, .boolean, .intervalDS:
+                .binaryInteger, .boolean, .intervalDS, .intervalYM:
                 switch buffer.readOracleSlice() {
                 case .some(let slice):
                     columnValue = slice
@@ -174,6 +174,14 @@ extension OracleBackendMessage {
                     return base.writerIndex - start
                 }
                 columnValue.writeInteger(0, as: UInt32.self)  // chunk length of zero
+            case .bfile:
+                let length = try buffer.throwingReadUB4()
+                if length > 0 {
+                    if !buffer.skipRawBytesChunked() {
+                        throw MissingDataDecodingError.Trigger()
+                    }
+                }
+                columnValue = .init(bytes: [0])
             case .clob, .blob:
 
                 // LOB has a UB4 length indicator instead of the usual UInt8
@@ -255,8 +263,8 @@ extension OracleBackendMessage {
                 }
                 columnValue.writeInteger(0, as: UInt32.self)  // chunk length of zero
             default:
-                fatalError(
-                    "\(String(reflecting: oracleType)) is not implemented, please file a bug report"
+                throw OraclePartialDecodingError.unsupportedDataType(
+                    type: oracleType ?? .undefined
                 )
             }
 
@@ -326,8 +334,9 @@ extension OracleBackendMessage {
             if actualBytesCount < 0 && metadata.dataType._oracleType == .boolean {
                 return ByteBuffer(bytes: [0])  // empty buffer
             } else if actualBytesCount != 0 && !columnData.oracleColumnIsEmpty {
-                // TODO: throw this as error?
-                preconditionFailure("column truncated, length: \(actualBytesCount)")
+                throw OraclePartialDecodingError.columnTruncated(
+                    length: Int(actualBytesCount)
+                )
             }
 
             return columnData

--- a/Sources/OracleNIO/OracleSQLError.swift
+++ b/Sources/OracleNIO/OracleSQLError.swift
@@ -45,6 +45,7 @@ public struct OracleSQLError: Sendable, Error {
             case unsupportedDataType
             case missingStatement
             case malformedStatement
+            case unsupportedVerifierType(UInt32)
         }
 
         @usableFromInline
@@ -141,6 +142,11 @@ public struct OracleSQLError: Sendable, Error {
         }
 
         @inlinable
+        public static func unsupportedVerifierType(_ flag: UInt32) -> Self {
+            Self(.unsupportedVerifierType(flag))
+        }
+
+        @inlinable
         public var description: String {
             switch self.base {
             case .clientClosesConnection:
@@ -177,6 +183,8 @@ public struct OracleSQLError: Sendable, Error {
                 return "missingStatement"
             case .malformedStatement:
                 return "malformedStatement"
+            case .unsupportedVerifierType(let flag):
+                return "unsupportedVerifierType(0x\(String(flag, radix: 16)))"
             }
         }
     }
@@ -458,6 +466,11 @@ public struct OracleSQLError: Sendable, Error {
     @inlinable
     static var serverVersionNotSupported: OracleSQLError {
         OracleSQLError(code: .serverVersionNotSupported)
+    }
+
+    @inlinable
+    static func unsupportedVerifierType(_ flag: UInt32) -> OracleSQLError {
+        OracleSQLError(code: .unsupportedVerifierType(flag))
     }
 
     @inlinable

--- a/Tests/OracleNIOTests/Auth/Oracle10GHashTests.swift
+++ b/Tests/OracleNIOTests/Auth/Oracle10GHashTests.swift
@@ -1,0 +1,59 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the OracleNIO open source project
+//
+// Copyright (c) 2026 Timo Zacherl and the OracleNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of OracleNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Testing
+
+@testable import OracleNIO
+
+@Suite("Oracle 10G password hash") struct Oracle10GHashTests {
+    @Test("Canonical passlib test vector: username/password -> 872805F3F4C83365")
+    func canonicalVector() {
+        let hash = Oracle10GHash.compute(username: "username", password: "password")
+        #expect(hash.hexString.uppercased() == "872805F3F4C83365")
+    }
+
+    @Test("Demo SCOTT/TIGER vector matches public reference")
+    func scottTiger() {
+        let hash = Oracle10GHash.compute(username: "SCOTT", password: "TIGER")
+        #expect(hash.hexString.uppercased() == "F894844C34402B67")
+    }
+
+    @Test("Lowercase input produces same hash as uppercase (case-insensitive 10G)")
+    func caseInsensitive() {
+        let upper = Oracle10GHash.compute(username: "SCOTT", password: "TIGER")
+        let lower = Oracle10GHash.compute(username: "scott", password: "tiger")
+        let mixed = Oracle10GHash.compute(username: "Scott", password: "TiGeR")
+        #expect(upper == lower)
+        #expect(upper == mixed)
+    }
+
+    @Test("Empty password produces a deterministic hash, no crash")
+    func emptyPassword() {
+        let hash = Oracle10GHash.compute(username: "USER", password: "")
+        #expect(hash.count == 8)
+    }
+
+    @Test("Output is always exactly 8 bytes")
+    func outputLength() {
+        let inputs: [(String, String)] = [
+            ("a", "b"),
+            ("longusername123", "longpassword456"),
+            ("X", "Y"),
+            ("SYSTEM", "MANAGER"),
+        ]
+        for (user, pass) in inputs {
+            #expect(Oracle10GHash.compute(username: user, password: pass).count == 8)
+        }
+    }
+}

--- a/Tests/OracleNIOTests/CapabilitiesTests.swift
+++ b/Tests/OracleNIOTests/CapabilitiesTests.swift
@@ -34,4 +34,50 @@ import Testing
         capabilities.adjustForServerCompileCapabilities(serverCaps)
         #expect(capabilities.supportsEndOfRequest == false)
     }
+
+    @Test("OOB check stays disabled when server omits TNS_ACCEPT_FLAG_CHECK_OOB")
+    func oobCheckRequiresServerFlag() {
+        var capabilities = Capabilities()
+        capabilities.adjustForProtocol(version: 319, options: 0, flags: 0)
+        #expect(capabilities.supportsOOBCheck == false)
+    }
+
+    @Test("OOB check is enabled only when server advertises TNS_ACCEPT_FLAG_CHECK_OOB")
+    func oobCheckEnabledByServerFlag() {
+        var capabilities = Capabilities()
+        capabilities.adjustForProtocol(
+            version: 319, options: 0, flags: Constants.TNS_ACCEPT_FLAG_CHECK_OOB
+        )
+        #expect(capabilities.supportsOOBCheck)
+    }
+
+    @Test("23ai TTC capability bytes match python-oracledb advertisement")
+    func ttcCapabilityBytesParity() {
+        let capabilities = Capabilities()
+        let ttc4 = capabilities.compileCapabilities[Constants.TNS_CCAP_TTC4]
+        let ttc5 = capabilities.compileCapabilities[Constants.TNS_CCAP_TTC5]
+        let oci3 = capabilities.compileCapabilities[Constants.TNS_CCAP_OCI3]
+        let backport2 = capabilities.compileCapabilities[Constants.TNS_CCAP_FEATURE_BACKPORT2]
+        let vectorFeatures = capabilities.compileCapabilities[Constants.TNS_CCAP_VECTOR_FEATURES]
+        let queueOptions = capabilities.compileCapabilities[Constants.TNS_CCAP_QUEUE_OPTIONS]
+        #expect(ttc4 & Constants.TNS_CCAP_TTC4_EXPLICIT_BOUNDARY != 0)
+        #expect(ttc5 & Constants.TNS_CCAP_TOKEN_SUPPORTED != 0)
+        #expect(ttc5 & Constants.TNS_CCAP_PIPELINING_SUPPORT != 0)
+        #expect(oci3 & Constants.TNS_CCAP_OCI3_OCSSYNC != 0)
+        #expect(backport2 & Constants.TNS_CCAP_END_USER_SEC_CTX_PIGGYBACK != 0)
+        #expect(vectorFeatures & Constants.TNS_CCAP_VECTOR_FEATURE_SPARSE != 0)
+        #expect(queueOptions & Constants.TNS_CCAP_DEQUEUE_WITH_SELECTOR != 0)
+    }
+
+    @Test("Capabilities round-trip preserves supportsOOBCheck through encode/decode")
+    func capabilitiesRoundTrip() throws {
+        var original = Capabilities()
+        original.adjustForProtocol(
+            version: 319, options: 0, flags: Constants.TNS_ACCEPT_FLAG_CHECK_OOB
+        )
+        var buffer = ByteBuffer()
+        try original.encode(into: &buffer)
+        let decoded = try Capabilities(from: &buffer)
+        #expect(decoded.supportsOOBCheck == original.supportsOOBCheck)
+    }
 }


### PR DESCRIPTION
processColumnData previously called fatalError when a column's _TNSDataType fell outside its allowlist (notably INTERVAL YEAR TO MONTH and BFILE), and preconditionFailure when an OUT-bind column length mismatched. Both crashes are unrecoverable from the consumer side and kill the host application.

Replace both with thrown OraclePartialDecodingError so the ByteToMessageDecoder loop can surface them as ordinary errors.

Add IntervalYM with OracleEncodable / OracleDecodable conformance mirroring IntervalDS so INTERVAL YEAR TO MONTH columns can be decoded to Swift values, and a minimal BFILE locator-passthrough case so BFILE columns stop crashing (content fetch out of scope).