### PR TITLE
Add OracleConnection.cancel() for server-side break

### DIFF
--- a/Sources/OracleNIO/Connection/OracleConnection.swift
+++ b/Sources/OracleNIO/Connection/OracleConnection.swift
@@ -443,6 +443,34 @@ extension OracleConnection: OracleConnectionProtocol {
         try await self._rollback().get()
     }
 
+    /// Asynchronously interrupt an in-flight statement on the
+    /// connection by sending a TNS `BREAK` marker to the server.
+    ///
+    /// The server aborts the running operation and replies with
+    /// `ORA-01013` ("user requested cancel of current operation"),
+    /// which is surfaced as ``OracleSQLError/Code-swift.struct/statementCancelled``
+    /// to the awaiting caller of
+    /// ``execute(_:options:logger:file:line:)-9b3i9`` (or as a
+    /// `.failure` on the `OracleRowSequence` if the cancellation
+    /// happens mid-fetch). The connection is reusable for subsequent
+    /// statements once the break has been acknowledged.
+    ///
+    /// This is the oracle-nio equivalent of `OCIBreak()` /
+    /// `python-oracledb`'s `Connection.cancel()`. It is safe to call
+    /// from any task and is a no-op when no statement is in flight.
+    public func cancel() {
+        let channel = self.channel
+        channel.eventLoop.execute {
+            do {
+                let handler = try channel.pipeline.syncOperations
+                    .handler(type: OracleChannelHandler.self)
+                handler.triggerBreak()
+            } catch {
+                // Channel pipeline closed or handler removed — nothing to break.
+            }
+        }
+    }
+
     /// Run a statement on the Oracle server the connection is connected to.
     ///
     /// - Parameters:

--- a/Sources/OracleNIO/ConnectionStateMachine/ConnectionStateMachine.swift
+++ b/Sources/OracleNIO/ConnectionStateMachine/ConnectionStateMachine.swift
@@ -149,6 +149,12 @@ struct ConnectionStateMachine {
         )
 
         case sendMarker(read: Bool)
+        /// Triggered by ``OracleConnection/cancel()``. Instructs the
+        /// channel handler to write a TNS `BREAK` marker so the server
+        /// aborts the in-flight statement with `ORA-01013`. The
+        /// awaiting `execute` promise (or the row stream) is failed
+        /// once that error reaches ``StatementStateMachine``.
+        case sendBreak(read: Bool)
     }
 
     private var state: State
@@ -723,6 +729,69 @@ struct ConnectionStateMachine {
             return self.closeConnectionAndCleanup(
                 .unexpectedBackendMessage(.error(error))
             )
+        }
+    }
+
+    /// Trigger a server-side break of the in-flight statement.
+    ///
+    /// Drives the wire-level handshake invoked by
+    /// ``OracleConnection/cancel()``. When a statement is in flight,
+    /// marks it as cancelled and emits a ``ConnectionAction/sendBreak(read:)``
+    /// so the channel handler writes a TNS `BREAK` marker. The server
+    /// aborts the operation with `ORA-01013`, and the existing
+    /// cancellation branch in ``StatementStateMachine/errorReceived(_:)``
+    /// resolves the awaiting promise (or row stream).
+    ///
+    /// If no statement is in flight the call is a no-op and returns
+    /// ``ConnectionAction/wait``.
+    mutating func triggerBreak() -> ConnectionAction {
+        switch self.state {
+        case .statement(var statement):
+            return self.avoidingStateMachineCoW { machine in
+                let outcome = statement.markCancelledForBreak()
+                machine.state = .statement(statement)
+                switch outcome {
+                case .wait:
+                    return .wait
+                case .sendInterrupt:
+                    // Force `markerState = .noMarkerSent` so the
+                    // server's BREAK acknowledgment marker drives the
+                    // existing ``markerReceived`` toggle, which sends
+                    // a RESET marker back. That BREAK → ACK → RESET
+                    // handshake matches python-oracledb's
+                    // `_break_external` followed by `_reset`.
+                    // Resetting also clears any stale toggle left
+                    // over from a previous break exchange.
+                    machine.markerState = .noMarkerSent
+                    return .sendBreak(read: true)
+                case .forwardStreamError(let stmtAction):
+                    // Mid-stream — same end state as dropping the
+                    // iterator. ``.forwardStreamError(clientCancelled:
+                    // true)`` is bridged in ``modify`` to the standard
+                    // sendMarker(RESET) follow-up.
+                    return machine.modify(with: stmtAction)
+                }
+            }
+        case .initialized,
+            .connectMessageSent,
+            .protocolMessageSent,
+            .dataTypesMessageSent,
+            .waitingToStartAuthentication,
+            .authenticating,
+            .renegotiatingTLS,
+            .readyForStatement,
+            .ping,
+            .commit,
+            .rollback,
+            .lobOperation,
+            .readyToLogOff,
+            .loggingOff,
+            .closing,
+            .closed,
+            .oobCheckInProgress:
+            return .wait
+        case .modifying:
+            preconditionFailure("Invalid state: \(self.state)")
         }
     }
 

--- a/Sources/OracleNIO/ConnectionStateMachine/StatementStateMachine.swift
+++ b/Sources/OracleNIO/ConnectionStateMachine/StatementStateMachine.swift
@@ -91,6 +91,68 @@ struct StatementStateMachine {
         )
     }
 
+    /// Result of ``markCancelledForBreak()`` — tells the connection
+    /// state machine which side-effect path to drive after marking
+    /// the statement cancelled.
+    enum BreakOutcome {
+        /// Pre-streaming state (`.initialized`, `.describeInfoReceived`,
+        /// `.rowCountsReceived`). Connection should send a TNS
+        /// `INTERRUPT` marker; the awaiting `execute` promise fails
+        /// once `ORA-01013` arrives.
+        case sendInterrupt
+        /// Mid-stream state. Connection should fail the row stream
+        /// locally and send a `RESET` marker — the existing client
+        /// cancel path. The forwarded action carries the
+        /// `.statementCancelled` error.
+        case forwardStreamError(Action)
+        /// Statement is already complete or already cancelled; no-op.
+        case wait
+    }
+
+    /// Mark the in-flight statement as cancelled by an external
+    /// ``OracleConnection/cancel()`` call. Returns the outcome that
+    /// tells the connection-level state machine which wire-level
+    /// handshake to perform.
+    mutating func markCancelledForBreak() -> BreakOutcome {
+        guard !self.isCancelled else { return .wait }
+
+        switch self.state {
+        case .commandComplete, .error, .drain:
+            return .wait
+
+        case .initialized, .describeInfoReceived, .rowCountsReceived:
+            // Substate is unchanged. The awaiting promise will be
+            // failed by ``errorReceived(_:)`` when `ORA-01013`
+            // arrives.
+            self.isCancelled = true
+            return .sendInterrupt
+
+        case .streaming(_, let describeInfo, _, var streamStateMachine):
+            // Mirror the existing in-flight-stream cancel path
+            // (``cancel()`` on `.streaming`): fail the row stream
+            // locally with `.statementCancelled`, transition to
+            // `.drain`, and let the connection emit its standard
+            // `sendMarker(RESET, read: true)` follow-up.
+            self.isCancelled = true
+            self.state = .drain(describeInfo.columns)
+            let action: Action
+            switch streamStateMachine.fail() {
+            case .wait:
+                action = .forwardStreamError(
+                    .statementCancelled, read: false, clientCancelled: true
+                )
+            case .read:
+                action = .forwardStreamError(
+                    .statementCancelled, read: true, clientCancelled: true
+                )
+            }
+            return .forwardStreamError(action)
+
+        case .modifying:
+            preconditionFailure("Invalid state: \(self.state)")
+        }
+    }
+
     mutating func cancel() -> Action {
         switch self.state {
         case .initialized:
@@ -383,8 +445,32 @@ struct StatementStateMachine {
                 preconditionFailure("Invalid state: \(self.state)")
             }
         } else if self.isCancelled && error.number == 1013 {
-            self.state = .commandComplete
-            action = .forwardCancelComplete
+            // ORA-01013 is the server's response to a client-initiated
+            // TNS BREAK marker (see ``OracleConnection/cancel()``). For
+            // pre-streaming states we still hold the awaiting `execute`
+            // promise; fail it with `.statementCancelled` so the
+            // awaiting Task throws the same error users see when the
+            // existing row-stream cancel path fires.
+            switch self.state {
+            case .initialized(let context),
+                .describeInfoReceived(let context, _),
+                .rowCountsReceived(let context, _):
+                self.state = .commandComplete
+                switch context.type {
+                case .ddl(let promise),
+                    .dml(let promise),
+                    .plsql(let promise),
+                    .query(let promise),
+                    .cursor(_, _, let promise),
+                    .plain(let promise):
+                    action = .failStatement(promise, with: .statementCancelled)
+                }
+            case .streaming, .drain, .commandComplete, .error:
+                self.state = .commandComplete
+                action = .forwardCancelComplete
+            case .modifying:
+                preconditionFailure("Invalid state: \(self.state)")
+            }
         } else if error.number == Constants.TNS_ERR_VAR_NOT_IN_SELECT_LIST,
             let cursor = error.cursorID
         {

--- a/Sources/OracleNIO/Constants.swift
+++ b/Sources/OracleNIO/Constants.swift
@@ -33,9 +33,9 @@ enum Constants {
     static let TNS_DATA_FLAGS_EOF: UInt16 = 0x0040
 
     // MARK: Marker types
-    static let TNS_MARKER_TYPE_BREAK = 1
+    static let TNS_MARKER_TYPE_BREAK: UInt8 = 1
     static let TNS_MARKER_TYPE_RESET: UInt8 = 2
-    static let TNS_MARKER_TYPE_INTERRUPT = 3
+    static let TNS_MARKER_TYPE_INTERRUPT: UInt8 = 3
 
     // MARK: Charset forms
     @usableFromInline

--- a/Sources/OracleNIO/Messages/Coding/OracleFrontendMessageEncoder.swift
+++ b/Sources/OracleNIO/Messages/Coding/OracleFrontendMessageEncoder.swift
@@ -47,12 +47,12 @@ struct OracleFrontendMessageEncoder {
         return self.buffer
     }
 
-    mutating func marker() {
+    mutating func marker(type: UInt8 = Constants.TNS_MARKER_TYPE_RESET) {
         self.clearIfNeeded()
 
         self.startRequest(packetType: .marker)
         self.buffer.writeMultipleIntegers(
-            UInt8(1), UInt8(0), Constants.TNS_MARKER_TYPE_RESET
+            UInt8(1), UInt8(0), type
         )
         self.endRequest(packetType: .marker)
     }

--- a/Sources/OracleNIO/OracleChannelHandler.swift
+++ b/Sources/OracleNIO/OracleChannelHandler.swift
@@ -461,6 +461,21 @@ final class OracleChannelHandler: ChannelDuplexHandler {
                 context.read()
             }
 
+        case .sendBreak(let read):
+            // TNS INTERRUPT marker — instructs the server to abort
+            // the in-flight operation. The server replies with an
+            // acknowledgment marker; the existing ``markerReceived``
+            // toggle then sends a RESET marker back, completing the
+            // break/reset handshake (mirrors python-oracledb's
+            // `_break_external` followed by `_reset`).
+            self.encoder.marker(type: Constants.TNS_MARKER_TYPE_INTERRUPT)
+            context.writeAndFlush(
+                self.wrapOutboundOut(self.encoder.flush()), promise: nil
+            )
+            if read {
+                context.read()
+            }
+
         case .sendPing:
             self.encoder.ping()
             context.writeAndFlush(
@@ -868,6 +883,17 @@ final class OracleChannelHandler: ChannelDuplexHandler {
             componentSpecificReleaseNumber: (fullVersionNumber >> 8) & 0x0f,
             platformSpecificReleaseNumber: fullVersionNumber & 0x0f
         )
+    }
+}
+
+extension OracleChannelHandler {
+    /// Trigger a server-side break of the in-flight statement.
+    /// Called from ``OracleConnection/cancel()``; must be dispatched
+    /// onto the channel's event loop by the caller.
+    func triggerBreak() {
+        guard let handlerContext else { return }
+        let action = self.state.triggerBreak()
+        self.run(action, with: handlerContext)
     }
 }
 

--- a/Tests/IntegrationTests/CancelTests.swift
+++ b/Tests/IntegrationTests/CancelTests.swift
@@ -1,0 +1,242 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the OracleNIO open source project
+//
+// Copyright (c) 2025 Timo Zacherl and the OracleNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE for license information
+// See CONTRIBUTORS.md for the list of OracleNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Logging
+import NIOConcurrencyHelpers
+import NIOCore
+import NIOPosix
+import OracleNIO
+import Testing
+
+#if canImport(FoundationEssentials)
+    import FoundationEssentials
+#else
+    import Foundation
+#endif
+
+/// End-to-end tests for ``OracleConnection/cancel()`` against a live
+/// Oracle Database. They cover the three statement substates the
+/// cancel handshake has to handle:
+///
+/// 1. **Pre-streaming** (statement parsing / executing / blocked in
+///    `dbms_session.sleep`) — TNS BREAK + RESET; promise fails with
+///    `.statementCancelled`.
+/// 2. **Mid-stream** (server is sending rows) — fail the row stream
+///    locally + RESET; row iterator throws `.statementCancelled`.
+/// 3. **Idle** — no statement in flight; cancel is a no-op.
+///
+/// Each test verifies both that the in-flight operation reports
+/// `.statementCancelled` *and* that a follow-up `SELECT` runs
+/// promptly (proving the connection isn't stuck waiting for the
+/// orphan operation to finish).
+@Suite(
+    .disabled(if: env("SMOKE_TEST_ONLY") == "1", "running only smoke test suite"),
+    .timeLimit(.minutes(2))
+)
+struct CancelTests {
+
+    private let group: EventLoopGroup
+    private var eventLoop: EventLoop { group.next() }
+
+    init() {
+        self.group = NIOSingletons.posixEventLoopGroup
+    }
+
+    /// Cancel during `dbms_session.sleep` — the canonical
+    /// pre-streaming case. The server's kernel sleep checks for
+    /// breaks at next opportunity, so the cancel→done window is
+    /// "a few seconds" rather than instant; a strict instant
+    /// assertion would be flaky here.
+    @Test func cancelDuringKernelSleep() async throws {
+        try await withOracleConnection(on: eventLoop) { conn in
+            try await Self.runCancelCase(
+                on: conn,
+                sql: "BEGIN dbms_session.sleep(10); END;",
+                cancelAfter: .seconds(1),
+                expectedFollowUpUnderSeconds: 8  // sleep would naturally take ~9s remaining
+            )
+        }
+    }
+
+    /// Cancel a CPU-bound query while it's executing on the server
+    /// (statement is in pre-streaming state, no rows produced yet).
+    /// Should interrupt nearly instantly because the PL/SQL VM /
+    /// SQL engine checks breaks at every fetch boundary.
+    @Test func cancelDuringCPUBoundExecute() async throws {
+        try await withOracleConnection(on: eventLoop) { conn in
+            try await Self.runCancelCase(
+                on: conn,
+                sql: """
+                    SELECT COUNT(*) FROM (
+                        SELECT a.n + b.n + c.n AS x
+                        FROM (SELECT ROWNUM n FROM dual CONNECT BY ROWNUM <= 1000) a,
+                             (SELECT ROWNUM n FROM dual CONNECT BY ROWNUM <= 1000) b,
+                             (SELECT ROWNUM n FROM dual CONNECT BY ROWNUM <= 1000) c
+                        WHERE MOD(a.n + b.n + c.n, 7) = 1
+                    )
+                    """,
+                cancelAfter: .milliseconds(500),
+                expectedFollowUpUnderSeconds: 2
+            )
+        }
+    }
+
+    /// Cancel mid-fetch — the row stream is actively streaming
+    /// rows when the cancel arrives. Hits the `.streaming` branch
+    /// of ``ConnectionStateMachine/triggerBreak()`` (delegates to
+    /// the existing iterator-drop path).
+    @Test func cancelMidFetch() async throws {
+        try await withOracleConnection(on: eventLoop) { conn in
+            let cancelExpectation = ManagedAtomicBool(false)
+
+            let runTask = Task.detached {
+                let stream = try await conn.execute(
+                    "SELECT level FROM dual CONNECT BY level <= 10000000",
+                    logger: .oracleTest
+                )
+                do {
+                    var rows = 0
+                    for try await _ in stream {
+                        rows += 1
+                        if rows == 100 { cancelExpectation.value = true }
+                    }
+                    Issue.record("expected the row stream to be cancelled")
+                } catch let error as OracleSQLError where error.code == .statementCancelled {
+                    // expected
+                } catch {
+                    Issue.record("unexpected error: \(error)")
+                }
+            }
+
+            // Wait until we've consumed at least 100 rows, then cancel.
+            let deadline = Date().addingTimeInterval(5)
+            while !cancelExpectation.value, Date() < deadline {
+                try await Task.sleep(for: .milliseconds(20))
+            }
+            #expect(cancelExpectation.value, "row stream never started fetching")
+            conn.cancel()
+            try? await runTask.value
+
+            // Connection should be reusable immediately.
+            let t0 = Date()
+            let stream = try await conn.execute("SELECT 1 FROM dual", logger: .oracleTest)
+            for try await _ in stream {}
+            #expect(Date().timeIntervalSince(t0) < 2)
+        }
+    }
+
+    /// Cancel while idle is a no-op, and subsequent statements
+    /// continue to work.
+    @Test func cancelOnIdleConnection() async throws {
+        try await withOracleConnection(on: eventLoop) { conn in
+            conn.cancel()
+            try? await Task.sleep(for: .milliseconds(50))
+            let stream = try await conn.execute("SELECT 1 FROM dual", logger: .oracleTest)
+            var count = 0
+            for try await _ in stream { count += 1 }
+            #expect(count == 1)
+        }
+    }
+
+    /// Two cancels in quick succession on the same in-flight
+    /// statement must not corrupt the connection — the second is
+    /// idempotent and the connection is reusable afterwards.
+    @Test func doubleCancelIsIdempotent() async throws {
+        try await withOracleConnection(on: eventLoop) { conn in
+            let runTask = Task.detached {
+                do {
+                    let stream = try await conn.execute(
+                        "BEGIN dbms_session.sleep(10); END;",
+                        logger: .oracleTest
+                    )
+                    for try await _ in stream {}
+                    Issue.record("expected cancellation")
+                } catch let error as OracleSQLError where error.code == .statementCancelled {
+                    // expected
+                } catch {
+                    Issue.record("unexpected error: \(error)")
+                }
+            }
+
+            try await Task.sleep(for: .milliseconds(500))
+            conn.cancel()
+            conn.cancel()  // second cancel — must be a no-op
+            await runTask.value
+
+            // Connection is reusable.
+            let stream = try await conn.execute("SELECT 1 FROM dual", logger: .oracleTest)
+            for try await _ in stream {}
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Run a cancel scenario: kick off `sql`, wait `cancelAfter`,
+    /// call `conn.cancel()`, expect the in-flight task to throw
+    /// `.statementCancelled`, then run a follow-up `SELECT 1` and
+    /// require it to complete in under `expectedFollowUpUnderSeconds`.
+    private static func runCancelCase(
+        on conn: OracleConnection,
+        sql: String,
+        cancelAfter: Duration,
+        expectedFollowUpUnderSeconds: Double
+    ) async throws {
+        let runTask = Task.detached {
+            do {
+                let stream = try await conn.execute(
+                    OracleStatement(unsafeSQL: sql), logger: .oracleTest
+                )
+                for try await _ in stream {}
+                Issue.record("expected cancellation, but SQL completed: \(sql)")
+            } catch let error as OracleSQLError where error.code == .statementCancelled {
+                // expected
+            } catch {
+                Issue.record("unexpected error from cancelled SQL: \(error)")
+            }
+        }
+
+        try await Task.sleep(for: cancelAfter)
+        let t0 = Date()
+        conn.cancel()
+
+        // Follow-up should run promptly once the server replies to
+        // the BREAK/RESET handshake.
+        let followUpStart = Date()
+        let stream = try await conn.execute("SELECT 'ok' FROM dual", logger: .oracleTest)
+        var sawRow = false
+        for try await _ in stream { sawRow = true }
+        #expect(sawRow, "follow-up SELECT returned no rows")
+        let elapsed = Date().timeIntervalSince(followUpStart)
+        #expect(
+            elapsed < expectedFollowUpUnderSeconds,
+            "follow-up SELECT took \(elapsed)s; expected < \(expectedFollowUpUnderSeconds)s"
+        )
+
+        await runTask.value
+        _ = t0
+    }
+}
+
+/// Lightweight `Sendable`-friendly atomic Bool used by the tests.
+private final class ManagedAtomicBool: @unchecked Sendable {
+    private let lock = NIOLock()
+    private var _value: Bool
+
+    init(_ initial: Bool) { _value = initial }
+
+    var value: Bool {
+        get { lock.withLock { _value } }
+        set { lock.withLock { _value = newValue } }
+    }
+}

--- a/Tests/OracleNIOTests/ConnectionStateMachine/StatementStateMachineTests.swift
+++ b/Tests/OracleNIOTests/ConnectionStateMachine/StatementStateMachineTests.swift
@@ -232,6 +232,139 @@ import Testing
         #expect(state.statementStreamCancelled() == .sendMarker(read: true))
     }
 
+    // MARK: - OracleConnection.cancel() / triggerBreak
+
+    /// Cancel via ``OracleConnection/cancel()`` while the statement
+    /// is still in `.initialized` (server hasn't responded yet — the
+    /// `dbms_session.sleep` repro). The connection sends a TNS
+    /// INTERRUPT marker, the server's BREAK ack drives the existing
+    /// marker toggle into a follow-up RESET, and the awaiting
+    /// promise fails with `.statementCancelled` once `ORA-01013`
+    /// arrives.
+    @Test func breakCancellationFromInitialized() throws {
+        let promise = EmbeddedEventLoop().makePromise(of: OracleRowStream.self)
+        promise.fail(OracleSQLError.uncleanShutdown)
+        let query: OracleStatement = "BEGIN dbms_session.sleep(10); END;"
+        let queryContext = StatementContext(statement: query, promise: promise)
+
+        var state = ConnectionStateMachine.readyForStatement()
+        #expect(
+            state.enqueue(task: .statement(queryContext))
+                == .sendExecute(queryContext, nil, cursorID: 0, requiresDefine: false, noPrefetch: false)
+        )
+
+        // Trigger the break while still in `.initialized`.
+        #expect(state.triggerBreak() == .sendBreak(read: true))
+
+        // Server BREAK ack → existing marker toggle echoes a RESET back.
+        #expect(state.markerReceived() == .sendMarker(read: false))
+
+        // ORA-01013 arrives; promise fails with `.statementCancelled`.
+        let cancel = state.backendErrorReceived(.userRequestedCancel(cursorID: 0))
+        #expect(cancel == .failStatement(promise, with: .statementCancelled, cleanupContext: nil))
+    }
+
+    /// Cancel after the server has already streamed `describeInfo`
+    /// but before any rows arrived. Same wire-level handshake as the
+    /// `.initialized` case.
+    @Test func breakCancellationFromDescribeInfoReceived() throws {
+        let promise = EmbeddedEventLoop().makePromise(of: OracleRowStream.self)
+        promise.fail(OracleSQLError.uncleanShutdown)
+        let query: OracleStatement = "SELECT 1 AS id FROM dual"
+        let queryContext = StatementContext(statement: query, promise: promise)
+
+        let describeInfo = DescribeInfo(columns: [
+            .init(
+                name: "ID", dataType: .number, dataTypeSize: 0,
+                precision: 11, scale: 0, bufferSize: 22,
+                nullsAllowed: true, typeScheme: nil, typeName: nil,
+                domainSchema: nil, domainName: nil,
+                annotations: [:], vectorDimensions: nil, vectorFormat: nil
+            )
+        ])
+
+        var state = ConnectionStateMachine.readyForStatement()
+        #expect(
+            state.enqueue(task: .statement(queryContext))
+                == .sendExecute(queryContext, nil, cursorID: 0, requiresDefine: false, noPrefetch: false)
+        )
+        #expect(state.describeInfoReceived(describeInfo) == .wait)
+
+        #expect(state.triggerBreak() == .sendBreak(read: true))
+        #expect(state.markerReceived() == .sendMarker(read: false))
+        let cancel = state.backendErrorReceived(.userRequestedCancel(cursorID: 1))
+        #expect(cancel == .failStatement(promise, with: .statementCancelled, cleanupContext: nil))
+    }
+
+    /// Cancel via ``OracleConnection/cancel()`` while a row stream
+    /// is mid-flight delegates to the existing
+    /// ``cancelStatementStream``-equivalent path — the row stream is
+    /// failed locally and a single TNS RESET marker is sent.
+    @Test func breakCancellationFromStreaming() throws {
+        let promise = EmbeddedEventLoop().makePromise(of: OracleRowStream.self)
+        promise.fail(OracleSQLError.uncleanShutdown)
+        let query: OracleStatement = "SELECT level FROM dual CONNECT BY level <= 10000000"
+        let queryContext = StatementContext(statement: query, promise: promise)
+
+        let describeInfo = DescribeInfo(columns: [
+            .init(
+                name: "LEVEL", dataType: .number, dataTypeSize: 0,
+                precision: 11, scale: 0, bufferSize: 22,
+                nullsAllowed: true, typeScheme: nil, typeName: nil,
+                domainSchema: nil, domainName: nil,
+                annotations: [:], vectorDimensions: nil, vectorFormat: nil
+            )
+        ])
+        let rowHeader = OracleBackendMessage.RowHeader()
+        let result = StatementResult(value: .describeInfo(describeInfo.columns))
+
+        var state = ConnectionStateMachine.readyForStatement()
+        #expect(
+            state.enqueue(task: .statement(queryContext))
+                == .sendExecute(queryContext, nil, cursorID: 0, requiresDefine: false, noPrefetch: false)
+        )
+        #expect(state.describeInfoReceived(describeInfo) == .wait)
+        #expect(state.rowHeaderReceived(rowHeader) == .succeedStatement(promise, result))
+        #expect(state.rowDataReceived(.init(1), capabilities: .init()) == .wait)
+
+        // Trigger break mid-stream — should fail the stream with
+        // `.statementCancelled` and `clientCancelled: true`.
+        #expect(
+            state.triggerBreak()
+                == .forwardStreamError(
+                    .statementCancelled, read: false, cursorID: nil, clientCancelled: true
+                )
+        )
+        // Connection-level follow-up sends a single RESET marker.
+        #expect(state.statementStreamCancelled() == .sendMarker(read: true))
+    }
+
+    /// `triggerBreak()` is a no-op when no statement is in flight
+    /// (e.g. `.readyForStatement`). The follow-up command can run
+    /// immediately.
+    @Test func breakOnIdleConnectionIsNoOp() throws {
+        var state = ConnectionStateMachine.readyForStatement()
+        #expect(state.triggerBreak() == .wait)
+    }
+
+    /// A second ``triggerBreak`` while the first is still in flight
+    /// is idempotent — it does not double-send markers.
+    @Test func breakIsIdempotent() throws {
+        let promise = EmbeddedEventLoop().makePromise(of: OracleRowStream.self)
+        promise.fail(OracleSQLError.uncleanShutdown)
+        let query: OracleStatement = "BEGIN dbms_session.sleep(10); END;"
+        let queryContext = StatementContext(statement: query, promise: promise)
+
+        var state = ConnectionStateMachine.readyForStatement()
+        #expect(
+            state.enqueue(task: .statement(queryContext))
+                == .sendExecute(queryContext, nil, cursorID: 0, requiresDefine: false, noPrefetch: false)
+        )
+        #expect(state.triggerBreak() == .sendBreak(read: true))
+        // Second trigger before the server reply must be a no-op.
+        #expect(state.triggerBreak() == .wait)
+    }
+
     @Test func cancellationDoesNotCrashOnBitVector() throws {
         let promise = EmbeddedEventLoop().makePromise(of: OracleRowStream.self)
         promise.fail(OracleSQLError.uncleanShutdown)  // we don't care about the error at all.

--- a/Tests/OracleNIOTests/TestUtils/ConnectionAction+TestUtils.swift
+++ b/Tests/OracleNIOTests/TestUtils/ConnectionAction+TestUtils.swift
@@ -146,6 +146,9 @@ extension ConnectionStateMachine.ConnectionAction: Equatable {
         case (.sendMarker, .sendMarker):
             return true
 
+        case (.sendBreak(let lhs), .sendBreak(let rhs)):
+            return lhs == rhs
+
         default:
             return false
         }

--- a/Tests/OracleNIOTests/TestUtils/OracleBackendMessage+TestUtils.swift
+++ b/Tests/OracleNIOTests/TestUtils/OracleBackendMessage+TestUtils.swift
@@ -50,4 +50,17 @@ extension BackendError {
         rowID: nil,
         batchErrors: []
     )
+
+    static func userRequestedCancel(cursorID: UInt16 = 1) -> BackendError {
+        BackendError(
+            number: 1013,
+            cursorID: cursorID,
+            position: 0,
+            rowCount: 0,
+            isWarning: false,
+            message: "ORA-01013: User requested cancel of current operation.",
+            rowID: nil,
+            batchErrors: []
+        )
+    }
 }


### PR DESCRIPTION
## Summary

Adds a public `OracleConnection.cancel()` API that asynchronously interrupts an in-flight statement on the server — the OCI `OCIBreak()` / python-oracledb `Connection.cancel()` equivalent.

```swift
let task = Task {
    try await conn.execute("BEGIN dbms_session.sleep(60); END;", logger: logger)
}
// elsewhere…
conn.cancel()  // server raises ORA-01013, the awaiting Task throws .statementCancelled
```

Without this, `Task.cancel()` on the awaited promise doesn't propagate to the wire, so the server keeps running and the next `execute(...)` queues behind it.

## Wire-level handshake

Mirrors python-oracledb's `_break_external` + `_reset` pair:

1. Client sends `TNS_MARKER_TYPE_INTERRUPT`.
2. Server replies with a BREAK acknowledgment marker.
3. The existing `markerReceived` toggle echoes a `TNS_MARKER_TYPE_RESET` back.
4. Server raises `ORA-01013` on the in-flight statement.
5. `StatementStateMachine.errorReceived(_:)` routes through the cancellation branch — extended in this PR to also fail the awaiting `execute` promise from the `.initialized`, `.describeInfoReceived`, and `.rowCountsReceived` substates (the existing `.streaming` path was already wired).

Mid-fetch cancels delegate to the existing iterator-drop path (`.forwardStreamError(clientCancelled: true)` followed by `sendMarker(RESET)`), so the wire bytes for `await stream.cancel()` style cancellation are unchanged.

## Why this also benefits non-cancel call sites

The PR makes the existing `cancelStatementStream` path slightly more robust:

- `markerState` is reset to `.noMarkerSent` in `triggerBreak()` so a cancel that follows another cancel doesn't get stuck on a stale toggle when the server elides one of the marker echoes.
- `errorReceived(_:)` now resolves the original `execute` promise on `ORA-01013` from any pre-streaming substate, where previously only `.streaming` produced a usable failure.

## Code changes

| File | What |
|---|---|
| `Sources/OracleNIO/Connection/OracleConnection.swift` | Public `cancel()` |
| `Sources/OracleNIO/OracleChannelHandler.swift` | `triggerBreak()` entry point + `.sendBreak` action handler |
| `Sources/OracleNIO/ConnectionStateMachine/ConnectionStateMachine.swift` | New `triggerBreak()` and `.sendBreak` case |
| `Sources/OracleNIO/ConnectionStateMachine/StatementStateMachine.swift` | New `markCancelledForBreak()` returning a `BreakOutcome`; widened `ORA-01013` handling |
| `Sources/OracleNIO/Messages/Coding/OracleFrontendMessageEncoder.swift` | `marker(type:)` overload |
| `Sources/OracleNIO/Constants.swift` | `TNS_MARKER_TYPE_BREAK` / `_INTERRUPT` typed as `UInt8` for the encoder |

## Test coverage

**Unit (5 new, all 363 existing still pass)**

`Tests/OracleNIOTests/ConnectionStateMachine/StatementStateMachineTests.swift`:

- `breakCancellationFromInitialized` — the canonical `dbms_session.sleep` repro, statement is in `.initialized`.
- `breakCancellationFromDescribeInfoReceived` — between describeInfo and rowHeader.
- `breakCancellationFromStreaming` — mid-stream, asserts the existing `forwardStreamError` + `sendMarker(read: true)` path is still produced.
- `breakOnIdleConnectionIsNoOp` — `.readyForStatement` produces `.wait`.
- `breakIsIdempotent` — second `triggerBreak()` before the server responds is a no-op.

**Integration (5 new, against a live DB)**

`Tests/IntegrationTests/CancelTests.swift`:

- `cancelDuringKernelSleep` — `BEGIN dbms_session.sleep(10); END;`, cancel after 1s; follow-up `SELECT` runs in well under 8s (the kernel sleep checks for breaks at finite intervals so this is order-of-seconds, not instant).
- `cancelDuringCPUBoundExecute` — cancel a CPU-bound `SELECT COUNT(*)` while it's executing; follow-up runs under 2s.
- `cancelMidFetch` — cancel during a 10M-row stream; iterator throws `.statementCancelled`, follow-up immediate.
- `cancelOnIdleConnection` — no statement in flight, follow-up unaffected.
- `doubleCancelIsIdempotent` — two cancels in quick succession leave the connection reusable.

All 5 pass against the local Oracle Free 23ai test container at the standard `ORA_HOSTNAME` / `ORA_PORT` / `ORA_SERVICE_NAME` / `ORA_USERNAME` / `ORA_PASSWORD` env.

## Notes

- `scripts/soundness.sh` passes (license headers, no unacceptable language, `swift-format` clean).
- DCO: commit is `Signed-off-by:`.
- API addition only — no breaking changes; all existing tests continue to pass.

Inspired by issue [iliasaz/macintora#15](https://github.com/iliasaz/macintora/issues/15) (Oracle SQL IDE) where the missing cancel was particularly visible.