### PR TITLE
Fix decoding error when receiving a warning packet

### DIFF
--- a/Sources/OracleNIO/Messages/BackendError.swift
+++ b/Sources/OracleNIO/Messages/BackendError.swift
@@ -38,14 +38,14 @@ struct BackendError: OracleBackendMessage.PayloadDecodable, Hashable, Sendable {
         from buffer: inout ByteBuffer,
         context: OracleBackendMessageDecoder.Context
     ) throws -> BackendError {
-        let number = try buffer.throwingReadInteger(as: UInt16.self)
+        let number = try buffer.throwingReadUB2()
         // error number
-        let length = try buffer.throwingReadInteger(as: UInt16.self)
+        let length = try buffer.throwingReadUB2()
         // length of error message
-        try buffer.throwingMoveReaderIndex(forwardBy: 2)  // skip flags
+        try buffer.throwingSkipUB2()
         let errorMessage: String? =
             if number != 0 && length > 0 {
-                try buffer.throwingReadString(length: Int(length)).replacing(/(^\s+|\s+$)/, with: "")
+                try buffer.readString().replacing(/(^\s+|\s+$)/, with: "")
             } else {
                 nil
             }

--- a/Tests/IntegrationTests/OracleClientTests.swift
+++ b/Tests/IntegrationTests/OracleClientTests.swift
@@ -36,7 +36,6 @@ import Testing
                             #expect(userID == 1)
                             #expect(name == "Timo")
                             #expect(age == 23)
-                            print("done: \(i)/10000")
                         }
                     }
                 }
@@ -68,7 +67,6 @@ import Testing
                             #expect(userID == 1)
                             #expect(name == "Timo")
                             #expect(age == 23)
-                            print("done: \(i)/10000")
                         }
                     }
                 }

--- a/Tests/IntegrationTests/OracleNIOTests.swift
+++ b/Tests/IntegrationTests/OracleNIOTests.swift
@@ -1152,6 +1152,69 @@ final class OracleNIOTests {
         #expect(rowCount == 1)
     }
 
+    @Test func warning() async throws {
+        let testUsername = "NIO_GRACE_TEST"
+        let testPassword = "TestPwd_123"
+        let profileName = "NIO_GRACE_PROFILE"
+
+        let sysConn =
+            try await OracleConnection
+            .connect(on: self.eventLoop, configuration: .privilegedTest(), id: 1, logger: .oracleTest)
+        defer { #expect(throws: Never.self, performing: { try sysConn.syncClose() }) }
+
+        _ = try? await sysConn.execute("DROP USER \(unescaped: testUsername) CASCADE", logger: .oracleTest)
+        _ = try? await sysConn.execute("DROP PROFILE \(unescaped: profileName)", logger: .oracleTest)
+
+        try await sysConn.execute(
+            """
+            CREATE PROFILE \(unescaped: profileName) LIMIT
+                PASSWORD_LIFE_TIME 1/86400
+                PASSWORD_GRACE_TIME 7
+            """, logger: .oracleTest)
+
+        try await sysConn.execute(
+            "CREATE USER \(unescaped: testUsername) IDENTIFIED BY \(unescaped: testPassword)",
+            logger: .oracleTest
+        )
+        try await sysConn.execute("GRANT CREATE SESSION TO \(unescaped: testUsername)", logger: .oracleTest)
+        try await sysConn.execute(
+            "ALTER USER \(unescaped: testUsername) PROFILE \(unescaped: profileName)",
+            logger: .oracleTest
+        )
+        // Re-set the password so Oracle stamps PTIME; then backdate it via USER$
+        // so account_status immediately reads EXPIRED(GRACE) without waiting.
+        try await sysConn.execute(
+            "ALTER USER \(unescaped: testUsername) IDENTIFIED BY \(unescaped: testPassword)",
+            logger: .oracleTest
+        )
+
+        // Wait for the 1-second PASSWORD_LIFE_TIME to elapse; account_status will
+        // read EXPIRED(GRACE) at the next login without touching any SYS tables.
+        try await Task.sleep(for: .seconds(2))
+
+        let config = OracleConnection.Configuration(
+            host: env("ORA_HOSTNAME") ?? "192.168.1.24",
+            port: env("ORA_PORT").flatMap(Int.init) ?? 1521,
+            service: .serviceName(env("ORA_SERVICE_NAME") ?? "XEPDB1"),
+            username: testUsername,
+            password: testPassword
+        )
+
+        let connection = try await OracleConnection.connect(
+            on: self.eventLoop, configuration: config, id: 0, logger: .oracleTest
+        )
+        defer { #expect(throws: Never.self) { try connection.syncClose() } }
+
+        let rows = try await connection.execute(
+            "SELECT 'grace-ok' FROM dual", logger: .oracleTest
+        ).collect()
+        #expect(rows.count == 1)
+        #expect(try rows.first?.decode(String.self) == "grace-ok")
+
+        _ = try? await sysConn.execute("DROP USER \(unescaped: testUsername) CASCADE", logger: .oracleTest)
+        _ = try? await sysConn.execute("DROP PROFILE \(unescaped: profileName)", logger: .oracleTest)
+    }
+
 }
 
 let isLoggingConfigured: Bool = {

--- a/Tests/IntegrationTests/OracleNIOTests.swift
+++ b/Tests/IntegrationTests/OracleNIOTests.swift
@@ -1168,7 +1168,7 @@ final class OracleNIOTests {
         try await sysConn.execute(
             """
             CREATE PROFILE \(unescaped: profileName) LIMIT
-                PASSWORD_LIFE_TIME 1/86400
+                PASSWORD_LIFE_TIME 2/86400
                 PASSWORD_GRACE_TIME 7
             """, logger: .oracleTest)
 
@@ -1188,9 +1188,8 @@ final class OracleNIOTests {
             logger: .oracleTest
         )
 
-        // Wait for the 1-second PASSWORD_LIFE_TIME to elapse; account_status will
-        // read EXPIRED(GRACE) at the next login without touching any SYS tables.
-        try await Task.sleep(for: .seconds(2))
+        // Wait for the 2-second PASSWORD_LIFE_TIME to elapse
+        try await Task.sleep(for: .seconds(5))
 
         let config = OracleConnection.Configuration(
             host: env("ORA_HOSTNAME") ?? "192.168.1.24",

--- a/Tests/IntegrationTests/OracleNIOTests.swift
+++ b/Tests/IntegrationTests/OracleNIOTests.swift
@@ -1152,7 +1152,7 @@ final class OracleNIOTests {
         #expect(rowCount == 1)
     }
 
-    @Test(.disabled(if: env("TEST_PRIVILEGED")?.isEmpty != false))  func warning() async throws {
+    @Test(.disabled(if: env("TEST_PRIVILEGED")?.isEmpty != false)) func warning() async throws {
         let testUsername = "NIO_GRACE_TEST"
         let testPassword = "TestPwd_123"
         let profileName = "NIO_GRACE_PROFILE"

--- a/Tests/IntegrationTests/OracleNIOTests.swift
+++ b/Tests/IntegrationTests/OracleNIOTests.swift
@@ -1152,7 +1152,7 @@ final class OracleNIOTests {
         #expect(rowCount == 1)
     }
 
-    @Test func warning() async throws {
+    @Test(.disabled(if: env("TEST_PRIVILEGED")?.isEmpty != false))  func warning() async throws {
         let testUsername = "NIO_GRACE_TEST"
         let testPassword = "TestPwd_123"
         let profileName = "NIO_GRACE_PROFILE"

--- a/scripts/check-license-headers.sh
+++ b/scripts/check-license-headers.sh
@@ -92,7 +92,7 @@ for FILE_PATH in "${PATHS_TO_CHECK_FOR_LICENSE[@]}"; do
   FILE_HEADER=$(head -n "${EXPECTED_FILE_HEADER_LINECOUNT}" "${FILE_PATH}")
   NORMALIZED_FILE_HEADER=$(
     echo "${FILE_HEADER}" \
-    | sed -e 's/202[345]-202[345]/YEARS/' -e 's/202[3456]/YEARS/' \
+    | sed -e 's/202[3456]-202[3456]/YEARS/' -e 's/202[3456]/YEARS/' \
   )
 
   if ! diff -u \


### PR DESCRIPTION
This is a follow up on #114, since that was too specific to the auth/connection process. And required setup work outside of the test. This implementation does all the setup inside tests and handles warnings the same way as errors. Closes #113 